### PR TITLE
Track dependnencies of .o files.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -310,10 +310,8 @@ FOREACH(name ${C_DEPS_SRC})
 
   ADD_CUSTOM_COMMAND (
     OUTPUT "${dst}"
-    # XXX BIS_OUTH is not a dependency for *every* C file.
-    #     This is a hack to make sure that bison stuff is
-    #     built before any C files are compiled.
-    DEPENDS "${src}" "${BIS_OUTH}"
+    MAIN_DEPENDENCY "${src}"
+    IMPLICIT_DEPENDS C "${src}"
     COMMAND
         ${SAC2C} -Xc -I${CMAKE_CURRENT_SOURCE_DIR}/${dir}
                  -Xc -I${CMAKE_CURRENT_BINARY_DIR}/${dir}


### PR DESCRIPTION
    When compiling .c -> .o header dependencies of .c should trigger
    rebuild of a sac module.