### PR TITLE
fighting further warnings;

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,7 +72,8 @@ ADD_CUSTOM_COMMAND (
 
 #flags needed for OSX (clang) as the generated code generates warning otherwise:
 SET (FLEX_SAC2C_CC_FLAGS "")
-CHECK_SAC2C_CC_FLAG("-Wno-unreachable-code" FLEX_SAC2C_CC_FLAGS)
+CHECK_SAC2C_CC_FLAG("-Wno-sign-compare" FLEX_SAC2C_CC_FLAGS) #needed on CentOS7
+CHECK_SAC2C_CC_FLAG("-Wno-unreachable-code" FLEX_SAC2C_CC_FLAGS) #needed on OSX 10.12
 
 SET (BISON_SAC2C_CC_FLAGS "")
 CHECK_SAC2C_CC_FLAG("-Wno-unreachable-code" BISON_SAC2C_CC_FLAGS)

--- a/src/stdio/src/BinFile/binfWriteDblArr.c
+++ b/src/stdio/src/BinFile/binfWriteDblArr.c
@@ -17,7 +17,7 @@ void SACbinfWriteDoubleArray(int fd, int dim, int *shp, double* array)
   }
 
   res = write(fd,array,size*sizeof(double));
-  if( res != size*sizeof(double)) {
+  if( (int)res != size*sizeof(double)) {
     SAC_RuntimeWarning( "only managed to write %d bytes of a %d byte array of doubles",
                          res, size*sizeof(double));
   }

--- a/src/system/RTClock.sac
+++ b/src/system/RTClock.sac
@@ -23,11 +23,12 @@ external void touch( RTClock &rtclock);
 #pragma linkname "SAC_RTClock_touch"
 #pragma linkobj "src/RTClock/rtclock.o"
 
+#if defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
 external long, long gettime();
 #pragma effect  RTClock::TheRTClock  
 #pragma linkname "SAC_RTClock_gettime"
 #pragma linkobj "src/RTClock/rtclock.o"
 #pragma linksign [1,2]
 
-
+#endif //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
 

--- a/src/system/RTimer.sac
+++ b/src/system/RTimer.sac
@@ -26,6 +26,8 @@ external void destroyRTimer( RTimer rtimer);
   #pragma linkwith "rt"
 #endif
 
+#if defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
+
 external void startRTimer( RTimer &rtimer);
 #pragma effect RTClock::TheRTClock
 #pragma linkname "SAC_RTimer_startRTimer"
@@ -41,6 +43,8 @@ external void stopRTimer( RTimer &rtimer);
 #ifdef NEED_LIBRT
   #pragma linkwith "rt"
 #endif
+
+#endif //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
 
 external void resetRTimer( RTimer &rtimer);
 #pragma linkname "SAC_RTimer_resetRTimer"

--- a/src/system/src/FileSystem/mktemp.c
+++ b/src/system/src/FileSystem/mktemp.c
@@ -1,4 +1,5 @@
-#include <unistd.h>
+#include <unistd.h>  // needed on OSX
+#include <stdlib.h>  // needed on linux
 
 char *
 SACmkdtemp (char *  template)

--- a/src/system/src/RTClock/rtclock.c
+++ b/src/system/src/RTClock/rtclock.c
@@ -8,6 +8,7 @@
  */
 
 #include <time.h>
+#include "libsac/essentials/message.h"
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -51,7 +52,10 @@ void SAC_RTClock_gettime( long *sec, long *nano)
   result.tv_nsec = mts.tv_nsec;
 
 #else
-#warning no implementation of SAC_RTClock_gettime on this target
+  SAC_RuntimeError( "When the stdlib was compiled for this architecture"
+                      " neither clock_gettime( CLOCK_REALTIME, x) "
+                      " nor host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, x)"
+                      " were found");
 #endif
 
   *sec = result.tv_sec;

--- a/src/system/src/RTimer/rtimer.c
+++ b/src/system/src/RTimer/rtimer.c
@@ -58,7 +58,10 @@ void current_utc_time(struct timespec *ts) {
     ts->tv_nsec = mts.tv_nsec;
 
 #else
-#warning no implementation of current_utc_time on this target
+    SAC_RuntimeError( "When the stdlib was compiled for this architecture"
+                      " neither clock_gettime( CLOCK_REALTIME, x) "
+                      " nor host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, x)"
+                      " were found");
 #endif
 
 }


### PR DESCRIPTION
disabled sign warnings in flex generated code
inserted explicit cast when checking ssize_t type against int
added more includes to find mkdtemp on linux
and eliminated #warning by a) inserting RuntimeErrors into the C code and b) eliding the corresponding SaC functions if impossible as to get compile time errors