### PR TITLE
Add Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ before_script:
 
 script:
     - cd build
-    - cmake -DTARGETS=mt_pth ..
+    - cmake -DTARGETS=mt_pth -DLINKSETSIZE=250 ..
     - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ before_script:
 
 script:
     - cd build
-    - cmake ..
-    - travis_wait 85 make -j2
+    - cmake -DBUILD_CORE=ON ..
+    - make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: c
+sudo: required
+dist: trusty # latest
+
+# install dependencies
+before_install:
+    # install dependecies for sac2c
+    - sudo apt-get update -qq
+    - sudo apt-get install -qq libhwloc-dev uuid-dev uuid-runtime
+    # install cmake
+    - CMAKE_URL="https://cmake.org/files/v3.8/cmake-3.8.0-Linux-x86_64.tar.gz"
+    - mkdir cmake-latest
+    - travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-latest
+    - export PATH=${TRAVIS_BUILD_DIR}/cmake-latest/bin:${PATH}
+    - cmake --version
+    # install sac2c
+    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.2-beta/Deb7/sac2c-1.2-beta-BlackForest-467-gce8d4-omnibus.deb
+    - sudo dpkg -i sac2c-1.2-beta-BlackForest-467-gce8d4-omnibus.deb
+
+before_script:
+    - mkdir build
+    - mkdir ${HOME}/.sac2crc
+
+script:
+    - cd build
+    - cmake ..
+    - travis_wait 85 make -j2

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,10 @@ before_install:
     - travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake-latest
     - export PATH=${TRAVIS_BUILD_DIR}/cmake-latest/bin:${PATH}
     - cmake --version
-    # install sac2c
-    - SAC2CDEB="sac2c-1.3.1-beta-MijasCosta-omnibus.deb"
-    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.3-beta/Ub14/${SAC2CDEB}
-    - sudo dpkg --force-all -i ${SAC2CDEB}
+    # install sac2c (always latest release)
+    - travis_retry wget --no-check-certificate --quiet -O sac2c.deb http://www.sac-home.org/packages/release/Ub14/latest
+    - sudo dpkg --force-all -i sac2c.deb
+    - sac2c -V
 
 before_script:
     - mkdir build
@@ -24,10 +24,10 @@ before_script:
 
 script:
     - cd build
+    # to save time we only build one target and increase the number of files we generate
     - cmake -DTARGETS=mt_pth -DLINKSETSIZE=250 ..
-    - make -j3 2>&1 | tee build.log
     # we need to test that make actually completed:
-    - travis_assert ${PIPESTATUS[0]}
+    - make -j3 2>&1 | tee build.log; travis_assert ${PIPESTATUS[0]}
     - if [ $(grep -i 'warning' build.log | wc -l) -gt 0 ]; then
         echo "+++ ${WARN_NUM} warnings detected +++";
         grep -i 'warning' build.log;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-sudo: required
+sudo: required # we get a VM + SUDO
 dist: trusty # latest
 
 # install dependencies
@@ -14,8 +14,8 @@ before_install:
     - export PATH=${TRAVIS_BUILD_DIR}/cmake-latest/bin:${PATH}
     - cmake --version
     # install sac2c
-    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.2-beta/Deb7/sac2c-1.2-beta-BlackForest-467-gce8d4-omnibus.deb
-    - sudo dpkg -i sac2c-1.2-beta-BlackForest-467-gce8d4-omnibus.deb
+    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.3-beta/Ub14/sac2c-1.3-beta-MijasCosta-omnibus.deb
+    - sudo dpkg --force-all -i sac2c-1.3-beta-MijasCosta-omnibus.deb
 
 before_script:
     - mkdir build
@@ -24,4 +24,9 @@ before_script:
 script:
     - cd build
     - cmake -DTARGETS=mt_pth -DLINKSETSIZE=250 ..
-    - make -j3
+    - make -j3 2>&1 | tee build.log
+    - if [ $(grep -i 'warning' build.log | wc -l) -gt 0 ]; then
+        echo "+++ ${WARN_NUM} warnings detected +++";
+        grep -i 'warning' build.log;
+        exit 1;
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,5 @@ before_script:
 
 script:
     - cd build
-    - cmake -DBUILD_CORE=ON ..
-    - make -j2
+    - cmake -DTARGETS=mt_pth ..
+    - make -j3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ before_install:
     - export PATH=${TRAVIS_BUILD_DIR}/cmake-latest/bin:${PATH}
     - cmake --version
     # install sac2c
-    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.3-beta/Ub14/sac2c-1.3-beta-MijasCosta-omnibus.deb
-    - sudo dpkg --force-all -i sac2c-1.3-beta-MijasCosta-omnibus.deb
+    - SAC2CDEB="sac2c-1.3.1-beta-MijasCosta-omnibus.deb"
+    - travis_retry wget --no-check-certificate --quiet http://www.sac-home.org/packages/DEB/1.3-beta/Ub14/${SAC2CDEB}
+    - sudo dpkg --force-all -i ${SAC2CDEB}
 
 before_script:
     - mkdir build
@@ -25,8 +26,10 @@ script:
     - cd build
     - cmake -DTARGETS=mt_pth -DLINKSETSIZE=250 ..
     - make -j3 2>&1 | tee build.log
+    # we need to test that make actually completed:
+    - travis_assert ${PIPESTATUS[0]}
     - if [ $(grep -i 'warning' build.log | wc -l) -gt 0 ]; then
         echo "+++ ${WARN_NUM} warnings detected +++";
         grep -i 'warning' build.log;
-        exit 1;
+        travis_terminate 1;
       fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,19 +12,25 @@ SET (TARGETS            seq mt_pth  CACHE STRING "Build stdlib-jpeg for these ta
 SET (SAC2C_EXEC                     CACHE STRING "A path to sac2c compiler")
 SET (LINKSETSIZE        "500"       CACHE STRING "Set a value for -linksetsize parameter of sac2c")
 OPTION (FULLTYPES "Include types such as long and longlong" OFF)
+OPTION (BUILD_EXT "Build complete Stdlib with extra modules" ON)
 
 SET (SAC2C_EXTRA_INC
-     -DHAVE_CONFIG_H -DEXT_STDLIB
+     -DHAVE_CONFIG_H
      -I${PROJECT_BINARY_DIR}/include
      -I${PROJECT_SOURCE_DIR}/include)
 
 SET (SAC2C_CPP_INC
-     -DHAVE_CONFIG_H -DEXT_STDLIB
+     -DHAVE_CONFIG_H
      -cppI${PROJECT_BINARY_DIR}/include
      -cppI${PROJECT_SOURCE_DIR}/include)
 
 IF (FULLTYPES)
     LIST (APPEND SAC2C_EXTRA_INC -DFULLTYPES)
+ENDIF ()
+
+IF (BUILD_EXT)
+    LIST (APPEND SAC2C_EXTRA_INC -DEXT_STDLIB)
+    LIST (APPEND SAC2C_CPP_INC -DEXT_STDLIB)
 ENDIF ()
 
 # Check whether sac2c is operational

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 SaC standard library
 ====================
 
+
+[![build status](https://travis-ci.org/SacBase/Stdlib.svg?branch=master)](https://travis-ci.org/SacBase/Stdlib) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/SacBase/Stdlib/issues)
+
 This repository consists of SaC modules with basic functionality like
 arithmetic, stdio, etc; which together form a standard library of SaC
 language.

--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ $ mkdir build
 $ cd build
 $ cmake ..
 $ make -j4  #you should have roughly 2GB per thread :-)
-$ make install
 ```
 
-**NOTE:** *When pulling the latest commit, remember to run `git submodule update` or you will
-be missing changes to the `cmake-common` repository.*
+If you like you can also install the stdlib into `/usr/local` with `make
+install`, but this is unnessicary as `sac2c` will be able to find your stdlib
+build automatically.
+
+**NOTE:** *When pulling the latest commit, remember to run `git submodule
+update` or you will be missing changes to the `cmake-common` repository.*
 
 Variables that can be passed to CMake
 =========================================
@@ -42,3 +45,5 @@ When running CMake it is possible to pass the following variables:
       *Default value: 500.*
   * `-DFULLTYPES=ON|OFF` --- add support for further types to the stdlib, such as `long` and
     `longlong` (Default is `OFF`).
+  * `-DBUILD_EXT=ON|OFF` --- build extended stdlib (see
+    `cmake/source-core-ext.txt` for details) (Default is `ON`)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ When running CMake it is possible to pass the following variables:
     for the number of C functions that are put in a single C file when compiling a SaC program.
     The rule of thumb:
     * value `0` is the fastest time-wise but potentially results in a large memory consumption
-    * value `1` reduces the memory consumption to minimum, buy significantly increases compilation time.
+    * value `1` reduces the memory consumption to minimum, but significantly increases compilation time.
     
       *Default value: 500.*
   * `-DFULLTYPES=ON|OFF` --- add support for further types to the stdlib, such as `long` and

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -100,4 +100,5 @@ MESSAGE ("
  * - realtime clock:       ${HAVE_GETTIME_REALTIME}
  * - mach clock:           ${HAVE_MACH_CLOCK_GET_TIME}
  * - full types:           ${FULLTYPES}
+ * - build extended:       ${BUILD_EXT}
 ")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -313,7 +313,7 @@ PARSE_CORE_EXT_CONFIG (
     XSAC_EXT_SRC)
 
 # By default we are always going to build extended version
-UNSET (BUILD_CORE)
+#UNSET (BUILD_CORE)
 IF (BUILD_CORE)
     SET (SAC_SRC  ${SAC_CORE_SRC})
     SET (XSAC_SRC ${XSAC_CORE_SRC})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -313,14 +313,12 @@ PARSE_CORE_EXT_CONFIG (
     XSAC_EXT_SRC)
 
 # By default we are always going to build extended version
-#UNSET (BUILD_CORE)
-IF (BUILD_CORE)
-    SET (SAC_SRC  ${SAC_CORE_SRC})
-    SET (XSAC_SRC ${XSAC_CORE_SRC})
-# Are we building extended stdlib
-ELSE ()
+IF (BUILD_EXT)
     SET (SAC_SRC  ${SAC_CORE_SRC} ${SAC_EXT_SRC})
     SET (XSAC_SRC  ${XSAC_CORE_SRC} ${XSAC_EXT_SRC})
+ELSE ()
+    SET (SAC_SRC  ${SAC_CORE_SRC})
+    SET (XSAC_SRC ${XSAC_CORE_SRC})
 ENDIF ()
 
 # This is the main target of the entire build, though it all modules are

--- a/src/system/src/GetOpt/getopt.c
+++ b/src/system/src/GetOpt/getopt.c
@@ -25,10 +25,11 @@
 int SACargc( void);
 char *SACargv(int n);
 
-static int optind = 1;
-static int opterr = 1;
-static int optopt;
-static char *optarg;
+int optind = 1;
+int opterr = 1;
+int optopt;
+char *optarg;
+
 static int argind = 1;
 
 int optEND(void)


### PR DESCRIPTION
This series of commits allows us now to build the StdLib on Travis - this is particular useful for pull-requests as it means we now have a means to verify requests actually build **without** errors or warnings.

A few notes about the setup:
-  Because Travis.org sets a hardlimit of 50 minutes for builds, we only build `mt_pth` target, as this takes less than 40 minutes. We also reduce the linksetsize to 250 in order *not* to run out of memory. Having said that, we do build the complete stdlib (core + extras).
- We use the Debian release version of sac2c (http://www.sac-home.org/doku.php?id=download:main) which is somewhat old now - my tests show that everything builds, so I think we are safe, but it means that potentially newer features will not be compiled as these are not supported by the compiler.