### PR TITLE
Add BUILDGENERIC flag to cmake that.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ SET (TARGETS            seq mt_pth  CACHE STRING "Build stdlib-jpeg for these ta
 SET (SAC2C_EXEC                     CACHE STRING "A path to sac2c compiler")
 SET (LINKSETSIZE        "500"       CACHE STRING "Set a value for -linksetsize parameter of sac2c")
 SET (IS_RELEASE         FALSE       CACHE BOOL "Indicate if we are building with release version of SAC2C")
+SET (BUILDGENERIC       FALSE       CACHE  BOOL "Should we suppress -mtune=native (useful for package builds)")
 OPTION (FULLTYPES "Include types such as long and longlong" OFF)
 OPTION (BUILD_EXT "Build complete Stdlib with extra modules" ON)
 
@@ -32,6 +33,10 @@ ENDIF ()
 IF (BUILD_EXT)
     LIST (APPEND SAC2C_EXTRA_INC -DEXT_STDLIB)
     LIST (APPEND SAC2C_CPP_INC -DEXT_STDLIB)
+ENDIF ()
+
+IF (BUILDGENERIC)
+    LIST (APPEND SAC2C_EXTRA_INC "-mtune=generic")
 ENDIF ()
 
 # Check whether sac2c is operational


### PR DESCRIPTION
    This is useful when building stdlib package, so that we avoid using
    -march=native -mtune=native in packages.  Otherwise there is a large
    likelihood that packages will brake on client's systems.