### PR TITLE
fix NVCC errors (C++ related)

### DIFF
--- a/src/stdio/src/PGM/array2pgm.c
+++ b/src/stdio/src/PGM/array2pgm.c
@@ -46,7 +46,7 @@ void SAC_PGM_write_header( PGM* pgm)
 void SAC_PGM_write_data( SAC_ND_PARAM_in_nodesc(array_nt, int),
                          PGM* pgm)
 {
-  int *restrict int_array = SAC_ND_A_FIELD(array_nt);
+  int *__restrict__ int_array = SAC_ND_A_FIELD(array_nt);
   const size_t pixelcount = pgm->height * pgm->width;
   size_t i = 0;
 

--- a/src/stdio/src/PPM/array2ppm.c
+++ b/src/stdio/src/PPM/array2ppm.c
@@ -16,6 +16,7 @@ void SAC_PPM_array2ppm( FILE *fp,
 {
   const int w = shape[1];
   const int h = shape[0];
+  int i, j;
 
   /*
    * ASCII output
@@ -26,8 +27,8 @@ void SAC_PPM_array2ppm( FILE *fp,
     fprintf(fp, "%d %d\n", w, h);
     fprintf(fp, "255\n");
 
-    for(int i = 0; i < h; i++) {
-      for (int j = 0; j < w; j++) {
+    for(i = 0; i < h; i++) {
+      for (j = 0; j < w; j++) {
         fprintf(fp, "%d %d %d", SAC_ND_A_FIELD(array_nt)[(i*w+j)*3],
                                 SAC_ND_A_FIELD(array_nt)[(i*w+j)*3+1],
                                 SAC_ND_A_FIELD(array_nt)[(i*w+j)*3+2]);
@@ -49,7 +50,7 @@ void SAC_PPM_array2ppm( FILE *fp,
     fprintf(fp, "%d %d\n", w, h);
     fprintf(fp, "255\n");
 
-    for(int i = 0; i < h * w * 3; i++) {
+    for(i = 0; i < h * w * 3; i++) {
       fprintf(fp, "%c", SAC_ND_A_FIELD(array_nt)[i]);
     }
   }

--- a/src/stdio/src/PPM/ppm2array.c
+++ b/src/stdio/src/PPM/ppm2array.c
@@ -21,6 +21,7 @@ void SAC_PPM_ppm2array( SAC_ND_PARAM_out( array_nt, int),
   char line[MAXLINE];
   int w;
   int h;
+  int i;
   int max;
   int *data;
   unsigned int c;
@@ -61,7 +62,7 @@ void SAC_PPM_ppm2array( SAC_ND_PARAM_out( array_nt, int),
       comment = true;
 
       while(comment == true) {
-        for(int i = 0; i < MAXLINE; i++) {
+        for(i = 0; i < MAXLINE; i++) {
           if (line[i] == '\n') {
             comment = false;
             break;
@@ -104,7 +105,7 @@ void SAC_PPM_ppm2array( SAC_ND_PARAM_out( array_nt, int),
    * Readout the image
    */
   if (binary == true) {
-    for (int i = 0; i < h*w*3; i++) {
+    for (i = 0; i < h*w*3; i++) {
       c = 0;
       if(fread(&c, 1, 1, fp) != 1) {
         SAC_RuntimeError( "Unexpected end of file" );
@@ -112,7 +113,7 @@ void SAC_PPM_ppm2array( SAC_ND_PARAM_out( array_nt, int),
       data[i] = c * (255/max);
     }
   } else {
-    for (int i = 0; i < h*w*3; i++) {
+    for (i = 0; i < h*w*3; i++) {
       if( fscanf(fp, "%d", &c) != 1) {
         SAC_RuntimeError( "Unexpected end of file");
       }
@@ -134,4 +135,3 @@ void SAC_PPM_ppm2array( SAC_ND_PARAM_out( array_nt, int),
   SAC_ND_A_FIELD( ret_nt) = data;
   SAC_ND_RET_out( array_nt, ret_nt)
 }
-         


### PR DESCRIPTION
When we compile with the cuda target, we use NVCC to compile both SaC
and C code. NVCC treats all the source code as C++. There are some parts of
the C sources within the stdlib which make uses of features that do not
exist within C++.

For instance the `restrict` pointer attribute, exists as a keyword
in C99, but not as part of C++. For GCC and CLANG for C/C++ there is
defined the `__restrict__` attribute which serves the same purpose as
`restrict`.

This commit makes the appropriate changes, now NVCC is happy.