### PR TITLE
extend generic flag to match sac2c flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ SET (TARGETS            seq mt_pth  CACHE STRING "Build stdlib-jpeg for these ta
 SET (SAC2C_EXEC                     CACHE STRING "A path to sac2c compiler")
 SET (LINKSETSIZE        "500"       CACHE STRING "Set a value for -linksetsize parameter of sac2c")
 SET (IS_RELEASE         FALSE       CACHE BOOL "Indicate if we are building with release version of SAC2C")
-SET (BUILDGENERIC       FALSE       CACHE  BOOL "Should we suppress -mtune=native (useful for package builds)")
+SET (BUILDGENERIC       FALSE       CACHE BOOL "Do not use architecture specific optimisations (useful for package builds)")
 OPTION (FULLTYPES "Include types such as long and longlong" OFF)
 OPTION (BUILD_EXT "Build complete Stdlib with extra modules" ON)
 
@@ -37,7 +37,7 @@ IF (BUILD_EXT)
 ENDIF ()
 
 IF (BUILDGENERIC)
-    LIST (APPEND SAC2C_EXTRA_INC "-mtune=generic")
+    LIST (APPEND SAC2C_CPP_INC "-generic")
 ENDIF ()
 
 # Check whether sac2c is operational

--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ Variables that can be passed to CMake
 =========================================
 
 When running CMake it is possible to pass the following variables:
-  * `-DTARGETS=x;y;z` --- build stdlib for targets x, y and z. (defaults are `seq; mt_pth`)
+  * `-DTARGETS=x;y;z` --- build stdlib for targets x, y and z. (Defaults to `seq;mt_pth`)
+  * `-DBUILDGENERIC=ON|OFF` --- build stdlib without using architecture specific optimisations
+  * (useful when creating distributable packages). (Default is `OFF`)
   * `-DSAC2C_EXEC=/path/to/sac2c` --- specify `sac2c` executable directly. Otherwise CMake will
     try to find `sac2c` on yout PATH.
   * `-DLINKSETSIZE=n` --- set `-linksetsize n` when calling `sac2c`.  This option is responsible


### PR DESCRIPTION
Now that sac2c has a `-generic` flag, we should use this instead of
trying to suppress `-mtune=native` in the C flags.