### PR TITLE
Use latest sac2c pkg (link change)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,7 @@ on: [pull_request]
 
 # high-level constants
 env:
-  BASE_URL: https://gitlab.science.ru.nl/sac-group/sac-packages/-/raw/master/packages/weekly
-  VERS: 1.3.3-383-1
-  SPKG: sac2c-1.3.3-MijasCosta-383-g6ea12-omnibus
+  BASE_URL: https://gitlab.science.ru.nl/sac-group/sac-packages/-/raw/master/latest/weekly
 
 # action listing, all jobs run in parallel
 jobs:
@@ -27,8 +25,8 @@ jobs:
           submodules: 'recursive'
       - name: Install sac2c-basic
         run: |
-          wget ${BASE_URL}/Ubl18/${VERS}/basic/${SPKG}.deb
-          sudo apt install ./${SPKG}.deb
+          wget ${BASE_URL}/Ubl18/sac2c-basic.deb
+          sudo apt install ./sac2c-basic.deb
           sac2c -V
       - name: Create build dir
         run: |
@@ -54,8 +52,8 @@ jobs:
           submodules: 'recursive'
       - name: Install sac2c-basic
         run: |
-          wget ${BASE_URL}/MacOS/${VERS}/basic/${SPKG}.pkg
-          sudo installer -pkg ./${SPKG}.pkg -target /
+          wget ${BASE_URL}/MacOS/sac2c-basic.pkg
+          sudo installer -pkg ./sac2c-basic.pkg -target /
           sac2c -V
       - name: Create build dir
         run: |


### PR DESCRIPTION
Latest MacOS VM in github actions changes Xcode version from 10 to 11, which required some changes within sac2c to work. We update our CI to use newer sac2c packages, where this problem is fixed. We switch to using a single link to always get the latest sac2c packages.