### PR TITLE
fix warning in FibreIO (mac-based systems)

### DIFF
--- a/src/stdio/src/FibreIO/FibreScan.l
+++ b/src/stdio/src/FibreIO/FibreScan.l
@@ -6,8 +6,6 @@
 #include <strings.h>
 #include <errno.h>
 
-#define yylval FibreScanlval
-
 #include "FibreScan.tab.h"
 extern int FibreScanparse( void);
 

--- a/src/stdio/src/FibreIO/FibreScan.y
+++ b/src/stdio/src/FibreIO/FibreScan.y
@@ -148,6 +148,13 @@ extern int yynerrs;
  */
 #define YYMAXDEPTH 1000000
 
+/*
+ * Make sure to indicate the yylval is defined externally, otherwise
+ * we get warnings from Clang. This definition needs to be here so that
+ * macro YYSTYPE is defined (via %union above).
+ */
+extern YYSTYPE yylval;
+
 %}
 
 


### PR DESCRIPTION
We now have a Mac system for the SaC CI, and we note that there is one warning being issued there:
```sh
[ 92%] Generating FibreIO Parser for target `mt_pth'
FibreScan.tab.c:1349:9: warning: no previous extern declaration for non-static variable 'FibreScanlval' [-Wmissing-variable-declarations]
YYSTYPE yylval;
        ^
/Users/sac/builds/eJzyRhzb/0/sac-group/sac2c/stdlib/src/stdio/src/FibreIO/FibreScan.h:30:16: note: expanded from macro 'yylval'
#define yylval FibreScanlval
               ^
FibreScan.tab.c:1349:1: note: declare 'static' if the variable is not intended to be used outside of this translation unit
YYSTYPE yylval;
^
1 warning generated.
```