### PR TITLE
re-add definition of yylval

### DIFF
--- a/src/stdio/src/FibreIO/FibreScan.l
+++ b/src/stdio/src/FibreIO/FibreScan.l
@@ -6,6 +6,8 @@
 #include <strings.h>
 #include <errno.h>
 
+#define yylval FibreScanlval
+
 #include "FibreScan.tab.h"
 extern int FibreScanparse( void);
 


### PR DESCRIPTION
This commit partially reverts commit "fix exten decl in FibreIO (MacOS warning)" 1d65a1ef7406225d765b514ffd95ed1d943e4cae, and re-introduces the definition of `yylval` --- without this we get warnings about `yylval` missing from `libFibreIOMod.so`, etc.

Bizarrely, when I removed this previously I don't notice any problem... then again I didn't actually run anything against the stdlib.... damn we really need tests?!