### PR TITLE
change to using MacOS 11 (Big Sur)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: cmake --build . -j 2
   build_mac:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Get HEAD and submodules
         uses: actions/checkout@v2
@@ -58,9 +58,9 @@ jobs:
       - name: Set XCode version
         run: |
           # this ensures we are using the same Xcode version that we compiled sac2c against
-          sudo xcode-select -switch "/Applications/Xcode_12.app"
+          sudo xcode-select -switch "/Applications/Xcode_12.5.app"
           # we need to rewrite sysroot path to use specific Xcode version
-          sudo find /usr/local/share -type f -name 'sac2crc_*' -execdir sed -i.bak 's/Xcode\.app/Xcode_12\.app/g' {} \;
+          sudo find /usr/local/share -type f -name 'sac2crc_*' -execdir sed -i.bak 's/Xcode\.app/Xcode_12\.5\.app/g' {} \;
       - name: Create build dir
         run: |
           cmake -E make_directory ${{runner.workspace}}/build


### PR DESCRIPTION
We use a M1 box to build sac2c, and so we require >= XCode 12.5.

**DO NOT MERGE**: `macos-11` support in GitHub is still not generally available, but I've sent in a request to have access to this. Only after this is approved can we merge the change.

For info from Github, see https://github.com/actions/virtual-environments/blob/main/docs/macos-11-onboarding.md.