### PR TITLE
check for warnings during build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,13 @@ jobs:
       - name: Build
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake --build . -j 2
+        run: |
+          cmake --build . -j 2 2>&1 | tee build.log
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "!!! ERROR detected in build !!!";
+            exit 1;
+          fi
+          ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log
   build_mac:
     runs-on: macos-11
     steps:
@@ -72,4 +78,10 @@ jobs:
       - name: Build
         shell: bash
         working-directory: ${{runner.workspace}}/build
-        run: cmake --build . -j 2
+        run: |
+          cmake --build . -j 2 2>&1 | tee build.log
+          if [ ${PIPESTATUS[0]} -ne 0 ]; then
+            echo "!!! ERROR detected in build !!!";
+            exit 1;
+          fi
+          ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Continuous Integration
 =====================
 
 We make use of Github Actions for our CI pipeline, building the standard library on different systems
-anytime there is a pull request.
+anytime there is a pull request. Build will fail if there are any compile-time warnings.
 
-Currently we build on the following systems: `ubuntu-18.04` and `macos-10.15`.
+Currently we build on the following systems: `ubuntu-18.04` and `macos-11`.
 
 Please look at `.github/workflows/` for more exact details on what we do.
 

--- a/ci/fail-on-warning.sh
+++ b/ci/fail-on-warning.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# the scipts reads from stdin/file the output of a build process (such as
+# through CMake/Autotools) and looks for text indicate that warning has
+# been issued. If it finds an instances of this, we return non-zero value.
+# Exceptions can be set, meaning that we don't consider all warnings as
+# a reason to return a non-zero value.
+
+# array join, supports delimiter. Usage: join_by ',' ${array}
+function join_by { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+
+# support stdin
+FILE="${1:-/dev/stdin}"
+
+# construct exclude array
+EXCLUDES=('was built for newer macOS version')
+TEXCLUDES="$(join_by '|' "${EXCLUDES[@]}")"
+
+# general search
+WARN_NUM=$(grep -i -F 'warning:' "$FILE" | grep -i -c -v -E "${TEXCLUDES}")
+if [ "${WARN_NUM}" -gt 0 ]; then
+  echo "+++ ${WARN_NUM} warnings detected +++";
+  exit 1
+fi


### PR DESCRIPTION
So far we have not checked for compile-time warnings, which is actually really useful. We no introduce a check for this, which is similar to the one used with the sac2c repo. If we detect any warnings (which we don't filter out), then we fail the build.