### PR TITLE
added mod-operation which is mapped to _aplmod_

### DIFF
--- a/include/Templates.mac
+++ b/include/Templates.mac
@@ -108,6 +108,7 @@ MAP_UNA_##ext( ++, _add_SxS_, a, a)     \
 MAP_UNA_##ext( --, _sub_SxS_, a, a)
 
 #define MAP_INT_OPS( ext, a)            \
+MAP_BIN_##ext( mod, _aplmod_SxS_, a, a) \
 MAP_BIN_##ext( %, _mod_SxS_, a, a)
 
 /********************************************************************************


### PR DESCRIPTION
Currently, we only define %, the C-style remainder function. However, for defining remainder-based rotate functions, we really would like to have an APL-style residue function. Fortunately, SaC supports that through _aplmod_SxS_. This extension adds a function "mod" that maps to _aplmod_SxS_. We considered using the APL symbold ('|') for residue as infix rather than prefix notation, however, in APL the modul is put *before* the bar which would create all kinds of confusion with the infix '%' of C.