### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           submodules: 'recursive'
       - name: Install sac2c-basic
         run: |
-          wget ${BASE_URL}/MacOS/sac2c-basic.pkg
+          wget ${BASE_URL}/MacOS_x86/sac2c-basic.pkg
           sudo installer -pkg ./sac2c-basic.pkg -target /
           sac2c -V
       - name: Set XCode version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ env:
 # action listing, all jobs run in parallel
 jobs:
   build_linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Get HEAD and submodules
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
           submodules: 'recursive'
       - name: Install sac2c-basic
         run: |
-          wget ${BASE_URL}/Ubl18/sac2c-basic.deb
+          wget ${BASE_URL}/Ubl20/sac2c-basic.deb
           sudo apt install ./sac2c-basic.deb
           sac2c -V
       - name: Create build dir
@@ -47,7 +47,7 @@ jobs:
           fi
           ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log
   build_mac:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - name: Get HEAD and submodules
         uses: actions/checkout@v2
@@ -64,9 +64,9 @@ jobs:
       - name: Set XCode version
         run: |
           # this ensures we are using the same Xcode version that we compiled sac2c against
-          sudo xcode-select -switch "/Applications/Xcode_12.5.app"
+          sudo xcode-select -switch "/Applications/Xcode_13.4.app"
           # we need to rewrite sysroot path to use specific Xcode version
-          sudo find /usr/local/share -type f -name 'sac2crc_*' -execdir sed -i.bak 's/Xcode\.app/Xcode_12\.5\.app/g' {} \;
+          sudo find /usr/local/share -type f -name 'sac2crc_*' -execdir sed -i.bak 's/Xcode\.app/Xcode_13\.4\.app/g' {} \;
       - name: Create build dir
         run: |
           cmake -E make_directory ${{runner.workspace}}/build


### PR DESCRIPTION
We no longer build for < Xcode 13 and we are building with a newer macos SDK, so this PR updates to the latest GitHub Actions runner for macos.

Additionally we update to Ubuntu 20.04 runner as 18.04 is deprecated (we will also drop this package upstream anyway in the near future).