### PR TITLE
bump cmake min version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED (VERSION 3.3)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.20)
 
 PROJECT (sac-stdlib)
 #FIXME(artem) we can create a definitoin for language "SAC" which will

--- a/README.md
+++ b/README.md
@@ -10,18 +10,16 @@ language.
 Build instructions
 ==================
 
-To build the system one requires an operational [CMake](https://cmake.org/) >= 3.3,
+To build the system one requires an operational [CMake](https://cmake.org/) >= 3.20,
 [Flex](http://flex.sourceforge.net/), and [Bison](https://www.gnu.org/software/bison/).
 
 An example on how to build the library:
-```bash
-$ cd Stdlib
-$ git submodule init
-$ git submodule update
-$ mkdir build
-$ cd build
-$ cmake ..
-$ make -j4  #you should have roughly 2GB per thread :-)
+```sh
+cd Stdlib
+git submodule init
+git submodule update
+cmake -B build
+cmake --build build -- -j4  # you should have roughly 2GB per thread :-)
 ```
 
 If you like you can also install the stdlib into `/usr/local` with `make

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED (VERSION 3.3)
+CMAKE_MINIMUM_REQUIRED (VERSION 3.20)
 INCLUDE ("${CMAKE_SOURCE_DIR}/cmake-common/sac2c-variables.cmake")
 INCLUDE ("${CMAKE_SOURCE_DIR}/cmake-common/generate-sac2c-dependency-targets.cmake")
 INCLUDE ("${CMAKE_SOURCE_DIR}/cmake/parse-core-ext-files.cmake")


### PR DESCRIPTION
This change bumps cmake minimum required version to 3.20, in response to issue #94.