### PR TITLE
Adjusted the build mechanism to the change in sac2c that ensures separate tree files for separate architectures

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ PROJECT (sac-stdlib)
 SET (DLL_BUILD_DIR  "${PROJECT_BINARY_DIR}/lib")
 
 # For what targets we build modules
-SET (TARGETS            seq mt_pth  CACHE STRING "Build stdlib for these targets")
+SET (TARGETS            seq seq_checks mt_pth CACHE STRING "Build stdlib for these targets")
 SET (SAC2C_EXEC                     CACHE STRING "A path to sac2c compiler")
 SET (LINKSETSIZE        "500"       CACHE STRING "Set a value for -linksetsize parameter of sac2c")
 SET (IS_RELEASE         FALSE       CACHE BOOL "Indicate if we are building with release version of SAC2C")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -437,9 +437,9 @@ FOREACH (name ${SAC_SRC})
     GET_FILENAME_COMPONENT (dir "${CMAKE_CURRENT_BINARY_DIR}/${name}" DIRECTORY)
     GET_FILENAME_COMPONENT (dst ${name} NAME_WE)
     SET (mod
-        "${DLL_BUILD_DIR}/${TARGET_ENV}/${SBI}/lib${dst}Mod${MODEXT}")
+        "${DLL_BUILD_DIR}/${TARGET_ENV}/${SBI}/lib${dst}Mod${VARIANT}${MODEXT}")
     SET (tree
-        "${DLL_BUILD_DIR}/tree/${TARGET_ENV}/lib${dst}Tree${TREE_DLLEXT}")
+        "${DLL_BUILD_DIR}/tree/${TARGET_ENV}/${SBI}/lib${dst}Tree${VARIANT}${TREE_DLLEXT}")
 
     RESOLVE_SAC_DEPS_AS_TARGETS ("${name}" "<TARGET>-module-<NAME>" target_list objs_list source_list)
     MESSAGE (STATUS "Computing dependencies for `${name}'")
@@ -490,7 +490,7 @@ FOREACH (name ${SAC_SRC})
     IF (NOT SAC_NOTREE)
         INSTALL (
             FILES "${tree}"
-            DESTINATION ${_install_tree_dir}/tree/${TARGET_ENV}
+            DESTINATION ${_install_tree_dir}/tree/${TARGET_ENV}/${SBI}
             COMPONENT trees)
     ENDIF ()
     UNSET (deps_list)
@@ -506,7 +506,7 @@ FOREACH (name ${XSAC_SRC})
     SET (mod
         "${DLL_BUILD_DIR}/${TARGET_ENV}/${SBI}/lib${dst}Mod${MODEXT}")
     SET (tree
-        "${DLL_BUILD_DIR}/tree/${TARGET_ENV}/lib${dst}Tree${TREE_DLLEXT}")
+        "${DLL_BUILD_DIR}/tree/${TARGET_ENV}/${SBI}/lib${dst}Tree${TREE_DLLEXT}")
 
     RESOLVE_SAC_DEPS_AS_TARGETS ("${name}" "<TARGET>-module-<NAME>" target_list objs_list source_list)
     MESSAGE (STATUS "Computing dependencies for `${name}'")
@@ -567,7 +567,7 @@ FOREACH (name ${XSAC_SRC})
     IF (NOT SAC_NOTREE)
         INSTALL (
             FILES "${tree}"
-            DESTINATION ${_install_tree_dir}/tree/${TARGET_ENV}
+            DESTINATION ${_install_tree_dir}/tree/${TARGET_ENV}/${SBI}
             COMPONENT trees)
     ENDIF ()
     UNSET (deps_list)


### PR DESCRIPTION
While the previous idea to share the tree libraries between different SBIs conceptually make sense, the problem is that parallel builds for separate targets led to race conditions in writing the tree libraries. Now, we create separate tree libraries for separate targets.