### PR TITLE
Extract `BUILT_IN` macro to separate `.mac` file to decrease coupling

### DIFF
--- a/include/Templates.mac
+++ b/include/Templates.mac
@@ -5,89 +5,15 @@
  * that these are used in several SaC modules. Among these are:
  *
  * ScalarArith.sac
- * ArrayBasics.sac
  * ArrayArith.sac
  * ArrayTransform.sac
  *
- ******************************************************************************/
-
-/******************************************************************************
+ * As well as through uses of UDTtemplates.mac in:
  *
- * Macros for mimicking polymorphism on elementary types.
- *
- ******************************************************************************/
-
-#ifdef FULLTYPES
-
-#define SIGNED_INT_NUM(fun)                                                    \
-fun(byte, b, 0b, 1b)                                                           \
-fun(short, s, 0s, 1s)                                                          \
-fun(int, i, 0i, 1i)                                                            \
-fun(long, l, 0l, 1l)                                                           \
-fun(longlong, ll, 0ll, 1ll)
-
-#define UNSIGNED_INT_NUM(fun)                                                  \
-fun(ubyte, ub, 0ub, 1ub)                                                       \
-fun(ushort, us, 0us, 1us)                                                      \
-fun(uint, ui, 0ui, 1ui)                                                        \
-fun(ulong, ul, 0ul, 1ul)                                                       \
-fun(ulonglong, ull, 0ull, 1ull)
-
-#else /* FULLTYPES */
-
-#define SIGNED_INT_NUM(fun)                                                    \
-fun(int, i, 0i, 1i)                                                            \
-fun(long, l, 0l, 1l)
-
-#define UNSIGNED_INT_NUM(fun)
-
-#endif /* FULLTYPES */
-
-#define INT_NUM(fun)                                                           \
-SIGNED_INT_NUM(fun)                                                            \
-UNSIGNED_INT_NUM(fun)
-
-#define REAL_NUM(fun)                                                          \
-fun(float, f, 0f, 1f)                                                          \
-fun(double, d, 0d, 1d)
-
-#define CHAR(fun)	                                                           \
-fun(char, /* no postfix */, ' ', ' ')
-
-#define BOOL(fun)                                                              \
-fun(bool, /* no postfix */, false, true)
-
-#define NUM(fun)                                                               \
-INT_NUM(fun)                                                                   \
-REAL_NUM(fun)
-
-#define SIGNED_NUM(fun)                                                        \
-SIGNED_INT_NUM(fun)                                                            \
-REAL_NUM(fun)
-
-/******************************************************************************
- *
- * Macro for generating a function for built-in types.
- *
- * It is of the following format:
- *
- * #define BUILT_IN(fun)
- *   fun(type, postfix, zero/false, one/true)
- *
- * @param type The name of the type.
- * @param postfix The postfix specifier for scalar values.
- *        E.g. 1i is an integer of value 1, whereas 1f is a float value.
- * @param zero/false The default zero/false value.
- *        E.g. false for booleans, or 0i for integers.
- * @param one/true The default zero/false value.
- *        E.g. true for booleans, or 1i for integers.
+ * ComplexArrayArith.mac
+ * ComplexArrayTransform.mac
  *
  ******************************************************************************/
-
-#define BUILT_IN(fun)                                                          \
-NUM(fun)                                                                       \
-CHAR(fun)                                                                      \
-BOOL(fun)
 
 /******************************************************************************
  *

--- a/include/builtin.mac
+++ b/include/builtin.mac
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *
+ * Macros for mimicking polymorphism on elementary types.
+ *
+ ******************************************************************************/
+
+#ifdef FULLTYPES
+
+#define SIGNED_INT_NUM(fun)                                                    \
+fun(byte, b, 0b, 1b)                                                           \
+fun(short, s, 0s, 1s)                                                          \
+fun(int, i, 0i, 1i)                                                            \
+fun(long, l, 0l, 1l)                                                           \
+fun(longlong, ll, 0ll, 1ll)
+
+#define UNSIGNED_INT_NUM(fun)                                                  \
+fun(ubyte, ub, 0ub, 1ub)                                                       \
+fun(ushort, us, 0us, 1us)                                                      \
+fun(uint, ui, 0ui, 1ui)                                                        \
+fun(ulong, ul, 0ul, 1ul)                                                       \
+fun(ulonglong, ull, 0ull, 1ull)
+
+#else /* FULLTYPES */
+
+#define SIGNED_INT_NUM(fun)                                                    \
+fun(int, i, 0i, 1i)                                                            \
+fun(long, l, 0l, 1l)
+
+#define UNSIGNED_INT_NUM(fun)
+
+#endif /* FULLTYPES */
+
+#define INT_NUM(fun)                                                           \
+SIGNED_INT_NUM(fun)                                                            \
+UNSIGNED_INT_NUM(fun)
+
+#define REAL_NUM(fun)                                                          \
+fun(float, f, 0f, 1f)                                                          \
+fun(double, d, 0d, 1d)
+
+#define CHAR(fun)	                                                           \
+fun(char, /* no postfix */, ' ', ' ')
+
+#define BOOL(fun)                                                              \
+fun(bool, /* no postfix */, false, true)
+
+#define SIGNED_NUM(fun)                                                        \
+SIGNED_INT_NUM(fun)                                                            \
+REAL_NUM(fun)
+
+#define NUM(fun)                                                               \
+INT_NUM(fun)                                                                   \
+REAL_NUM(fun)
+
+/******************************************************************************
+ *
+ * Macro for generating a function for built-in types.
+ *
+ * It is of the following format:
+ *
+ * #define BUILT_IN(fun)
+ *   fun(type, postfix, zero/false, one/true)
+ *
+ * @param type: The name of the type.
+ * @param postfix: The postfix specifier for scalar values.
+ *        E.g. 1i is an integer of value 1, whereas 1f is a float value.
+ * @param zero/false: The default zero/false value.
+ *        E.g. 0i for integers or false for booleans.
+ * @param one/true: The default zero/false value.
+ *        E.g. 1i for integers or true for booleans.
+ *
+ ******************************************************************************/
+
+#define BUILT_IN(fun)                                                          \
+NUM(fun)                                                                       \
+CHAR(fun)                                                                      \
+BOOL(fun)

--- a/src/stdio/ArrayIO.xsac
+++ b/src/stdio/ArrayIO.xsac
@@ -1,106 +1,112 @@
 module ArrayIO;
 
+ /******************************************************************************
+ *
+ * Depends on Array, String, ArrayFormat, TermFile, and File.
+ *
+ ******************************************************************************/
 
-use IOresources: all;
-/*use ArrayBasics : all;*/
-use ArrayFormat: all;
-use Structures: all;
-use TermFile: {TermFile};
+use Array: all;
+use String: { string };
+use ArrayFormat: { format };
+use TermFile: { TermFile, stdout };
+use File: { File };
 
-export { print, fprint, show};
+export { print, fprint, show };
 
-#include "Templates.mac"
+#include "builtin.mac"
 
 #define HASH #
 #define PRINTME(x) x
 #define QUOTEME(x) #x
 
-#define LINKSPECS(actualtype, typename)                                       \
-external void printarray(File &stream, int d, int[.] s, actualtype[*] a);     \
-  PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##Array)       \
-  PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"               \
-external void printarray(TermFile &stream, int d, int[.] s, actualtype[*] a); \
-  PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##Array)       \
-  PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"               \
-external void printarray(File &stream, string fmt,                            \
-                         int d, int[.] s, actualtype[*] a);                   \
-  PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##ArrayFormat) \
-  PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"               \
-external void printarray(TermFile &stream, string fmt, int d,                 \
-                         int[.] s, actualtype[*] a);                          \
-  PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##ArrayFormat) \
-  PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"
+#define LINKSPECS(actualtype, typename)                                        \
+external void printarray(File &stream, int d,                                  \
+                         int[.] s, actualtype[*] a);                           \
+    PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##Array)      \
+    PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"                     \
+external void printarray(TermFile &stream, int d,                              \
+                         int[.] s, actualtype[*] a);                           \
+    PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##Array)      \
+    PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"                     \
+external void printarray(File &stream, string fmt, int d,                      \
+                         int[.] s, actualtype[*] a);                           \
+    PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##ArrayFormat)\
+    PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"                     \
+external void printarray(TermFile &stream, string fmt, int d,                  \
+                         int[.] s, actualtype[*] a);                           \
+    PRINTME(HASH)pragma linkname QUOTEME(ARRAYIO__Print##typename##ArrayFormat)\
+    PRINTME(HASH)pragma linkobj "src/ArrayIO/PrintArray.o"
 
-LINKSPECS (bool, Bool)
-LINKSPECS (byte, Byte)
-LINKSPECS (short, Short)
-LINKSPECS (int, Int)
-LINKSPECS (long, Long)
-LINKSPECS (longlong, Longlong)
-LINKSPECS (ubyte, Ubyte)
-LINKSPECS (ushort, Ushort)
-LINKSPECS (uint, Uint)
-LINKSPECS (ulong, Ulong)
-LINKSPECS (ulonglong, Ulonglong)
-LINKSPECS (float, Float)
-LINKSPECS (double, Double)
-LINKSPECS (char, Char)
+LINKSPECS(bool, Bool)
+LINKSPECS(byte, Byte)
+LINKSPECS(short, Short)
+LINKSPECS(int, Int)
+LINKSPECS(long, Long)
+LINKSPECS(longlong, Longlong)
+LINKSPECS(ubyte, Ubyte)
+LINKSPECS(ushort, Ushort)
+LINKSPECS(uint, Uint)
+LINKSPECS(ulong, Ulong)
+LINKSPECS(ulonglong, Ulonglong)
+LINKSPECS(float, Float)
+LINKSPECS(double, Double)
+LINKSPECS(char, Char)
 
 external void showarray(File &stream, int d, int[.] s, char[*] a);
     #pragma linkname "ARRAYIO__ShowCharArray"
     #pragma linkobj "src/ArrayIO/ShowArray.o"
-
 external void showarray(TermFile &stream, int d, int[.] s, char[*] a);
     #pragma linkname "ARRAYIO__ShowCharArray"
     #pragma linkobj "src/ArrayIO/ShowArray.o"
 
+/******************************************************************************/
 
-#define PRINT( typ, postfix, zero, one)                                \
-inline void fprint(File &stream, typ[+] arr)                            \
-{                                                                       \
-  printarray(stream, dim(arr), shape(arr), arr);                        \
-}                                                                       \
-                                                                        \
-inline void fprint(TermFile &stream, typ[+] arr)                        \
-{                                                                       \
-  printarray(stream, dim(arr), shape(arr), arr);                        \
-}                                                                       \
-                                                                        \
-inline void print(typ[+] arr)                                           \
-{                                                                       \
-  printarray(stdout, dim(arr), shape(arr), arr);                        \
-}                                                                       \
-                                                                        \
-                                                                        \
-                                                                        \
-inline void fprint(File &stream, string fmt, typ[+] arr)                \
-{                                                                       \
-  printarray(stream, fmt, dim(arr), shape(arr), arr);                   \
-}                                                                       \
-                                                                        \
-inline void fprint(TermFile &stream, string fmt, typ[+] arr)            \
-{                                                                       \
-  printarray(stream, fmt, dim(arr), shape(arr), arr);                   \
-}                                                                       \
-                                                                        \
-inline void print(string fmt, typ[+] arr)                               \
-{                                                                       \
-  printarray(stdout, fmt, dim(arr), shape(arr), arr);                   \
-}                                                                       \
-
-#define SHOW(actualtype)                                                \
-inline void show(actualtype[+] arr)                                     \
-{                                                                       \
-  carr=format( arr);                                                    \
-  showarray(stdout, dim(carr), shape(carr), carr);                      \
+#define PRINT(typ, postfix, zero, one)                                         \
+inline void fprint(TermFile &stream, string fmt, typ[d:shp] arr)               \
+{                                                                              \
+    printarray(stream, fmt, d, shp, arr);                                      \
+}                                                                              \
+                                                                               \
+inline void fprint(TermFile &stream, typ[d:shp] arr)                           \
+{                                                                              \
+    printarray(stream, d, shp, arr);                                           \
+}                                                                              \
+                                                                               \
+inline void fprint(File &stream, string fmt, typ[d:shp] arr)                   \
+{                                                                              \
+    printarray(stream, fmt, d, shp, arr);                                      \
+}                                                                              \
+                                                                               \
+inline void fprint(File &stream, typ[d:shp] arr)                               \
+{                                                                              \
+    printarray(stream, d, shp, arr);                                           \
+}                                                                              \
+                                                                               \
+inline void print(string fmt, typ[d:shp] arr)                                  \
+{                                                                              \
+    printarray(stdout, fmt, d, shp, arr);                                      \
+}                                                                              \
+                                                                               \
+inline void print(typ[d:shp] arr)                                              \
+{                                                                              \
+    printarray(stdout, d, shp, arr);                                           \
 }
 
+BUILT_IN(PRINT)
 
-BUILT_IN( PRINT)
-/*BUILT_IN( SHOW)*/
+/******************************************************************************/
 
-SHOW( int)
-SHOW( float)
-SHOW( double)
-SHOW( bool)
-SHOW( char)
+#define SHOW(typ)                                                              \
+inline void show(typ[+] arr)                                                   \
+{                                                                              \
+    carr = format(arr);                                                        \
+    showarray(stdout, dim(carr), shape(carr), carr);                           \
+}
+
+/*BUILT_IN(SHOW)*/
+SHOW(int)
+SHOW(float)
+SHOW(double)
+SHOW(bool)
+SHOW(char)

--- a/src/structures/ArrayArith.xsac
+++ b/src/structures/ArrayArith.xsac
@@ -4,6 +4,7 @@ import ScalarArith: all;
 
 export all;
 
+#include "builtin.mac"
 #include "Templates.mac"
 
 /******************************************************************************

--- a/src/structures/ArrayBasics.xsac
+++ b/src/structures/ArrayBasics.xsac
@@ -2,7 +2,7 @@ module ArrayBasics;
 
 export all;
 
-#include "Templates.mac"
+#include "builtin.mac"
 
 /******************************************************************************
  *

--- a/src/structures/ArrayFormat.xsac
+++ b/src/structures/ArrayFormat.xsac
@@ -5,8 +5,6 @@ use String: { tochar, sprintf };
 
 export { format };
 
-#include "Templates.mac"
-
 /******************************************************************************
  *
  * APL Array formatting functions.

--- a/src/structures/ArrayTransform.xsac
+++ b/src/structures/ArrayTransform.xsac
@@ -11,6 +11,7 @@ use Constants: all;
 
 export all;
 
+#include "builtin.mac"
 #include "Templates.mac"
 
  /******************************************************************************

--- a/src/structures/ArrayTransform.xsac
+++ b/src/structures/ArrayTransform.xsac
@@ -12,7 +12,6 @@ use Constants: all;
 export all;
 
 #include "builtin.mac"
-#include "Templates.mac"
 
  /******************************************************************************
  *

--- a/src/structures/Char.sac
+++ b/src/structures/Char.sac
@@ -2,7 +2,7 @@ module Char;
 
 export all;
 
-#include "Templates.mac"
+#include "builtin.mac"
 
 /******************************************************************************
  *

--- a/src/structures/ComplexArrayBasics.xsac
+++ b/src/structures/ComplexArrayBasics.xsac
@@ -10,8 +10,6 @@ use ComplexBasics: { complex };
 
 export all;
 
-#include "Templates.mac"
-
 /******************************************************************************
  *
  * @fn int dim(complex[*] arr)

--- a/src/structures/ScalarArith.xsac
+++ b/src/structures/ScalarArith.xsac
@@ -2,19 +2,20 @@ module ScalarArith;
 
 export all;
 
+#include "builtin.mac"
 #include "Templates.mac"
 
 /******************************************************************************
  *
  * @fn <a> zero(<a>[*] A)
  *
- * @brief Yields a scalar zero of the element type of its argument.
+ * @brief Yields a scalar zero of the element typ of its argument.
  *
  ******************************************************************************/
 
-#define ZERO(type, postfix, zval, oval)                                        \
+#define ZERO(typ, postfix, zval, oval)                                        \
 inline                                                                         \
-type zero(type[*] A)                                                           \
+typ zero(typ[*] A)                                                           \
 {                                                                              \
     return zval;                                                               \
 }
@@ -25,13 +26,13 @@ BUILT_IN(ZERO)
  *
  * @fn <a> one(<a>[*] A)
  *
- * @brief Yields a scalar one of the element type of its argument.
+ * @brief Yields a scalar one of the element typ of its argument.
  *
  ******************************************************************************/
 
-#define ONE(type, postfix, zval, oval)                                         \
+#define ONE(typ, postfix, zval, oval)                                         \
 inline                                                                         \
-type one(type[*] A)                                                            \
+typ one(typ[*] A)                                                            \
 {                                                                              \
     return oval;                                                               \
 }
@@ -74,18 +75,18 @@ a name(a A)                                                                    \
  *
  ******************************************************************************/
 
-#define ARI_OPS_S(type, postfix, zval, oval)                                   \
-MAP_ARI_OPS(SxS, type)
+#define ARI_OPS_S(typ, postfix, zval, oval)                                   \
+MAP_ARI_OPS(SxS, typ)
 
 NUM(ARI_OPS_S)
 
 /******************************************************************************/
 
-#define ABS_OP_S(type, postfix, zval, oval)                                    \
-MAP_ABS_OP(SxS, type)
+#define ABS_OP_S(typ, postfix, zval, oval)                                    \
+MAP_ABS_OP(SxS, typ)
 
-#define ABS_NOOP_S(type, postfix, zval, oval)                                  \
-MAP_ABS_NOOP(SxS, type)
+#define ABS_NOOP_S(typ, postfix, zval, oval)                                  \
+MAP_ABS_NOOP(SxS, typ)
 
 SIGNED_NUM(ABS_OP_S)
 // abs is noop on unsigned numbers
@@ -93,23 +94,23 @@ UNSIGNED_INT_NUM(ABS_NOOP_S)
 
 /******************************************************************************/
 
-#define NEG_OP_S(type, postfix, zval, oval)                                    \
-MAP_NEG_OP(SxS, type)
+#define NEG_OP_S(typ, postfix, zval, oval)                                    \
+MAP_NEG_OP(SxS, typ)
 
 // neg only works on signed integers and reals
 SIGNED_NUM(NEG_OP_S)
 
 /******************************************************************************/
 
-#define ANA_OPS_S(type, postfix, zval, oval)                                   \
-MAP_ANA_OPS(S, type)
+#define ANA_OPS_S(typ, postfix, zval, oval)                                   \
+MAP_ANA_OPS(S, typ)
 
 NUM(ANA_OPS_S)
 
 /******************************************************************************/
 
-#define INT_OPS_S(type, postfix, zval, oval)                                   \
-MAP_INT_OPS(SxS, type)
+#define INT_OPS_S(typ, postfix, zval, oval)                                   \
+MAP_INT_OPS(SxS, typ)
 
 // mod only supports whole numbers
 INT_NUM(INT_OPS_S)
@@ -120,8 +121,8 @@ INT_NUM(INT_OPS_S)
  *
  ******************************************************************************/
 
-#define REL_OPS_S(type, postfix, zero, one)                                    \
-MAP_REL_OPS(SxS, type)
+#define REL_OPS_S(typ, postfix, zero, one)                                    \
+MAP_REL_OPS(SxS, typ)
 
 BUILT_IN(REL_OPS_S)
 
@@ -139,13 +140,13 @@ MAP_LOG_OPS(SxS)
  *
  ******************************************************************************/
 
-#define BOOL_CONV_OP_S(type, postfix, zero, one)                               \
-MAP_BOOL_CONV_OP(SxS, type)
+#define BOOL_CONV_OP_S(typ, postfix, zero, one)                               \
+MAP_BOOL_CONV_OP(SxS, typ)
 
 NUM(BOOL_CONV_OP_S)
 BOOL(BOOL_CONV_OP_S)
 
-#define NUM_CONV_OPS_S(type, postfix, zero, one)                               \
-MAP_NUM_CONV_OPS(SxS, type)
+#define NUM_CONV_OPS_S(typ, postfix, zero, one)                               \
+MAP_NUM_CONV_OPS(SxS, typ)
 
 BUILT_IN(NUM_CONV_OPS_S)

--- a/src/utrace/UTrace.sac
+++ b/src/utrace/UTrace.sac
@@ -14,7 +14,12 @@ use Indent: all;
 
 export all except { offset, whitespace, printSeparator, printHeader };
 
-#include "builtin.mac"
+#define BUILT_IN(fun)                                                          \
+fun(int)                                                                       \
+fun(float)                                                                     \
+fun(double)                                                                    \
+fun(bool)                                                                      \
+fun(char)
 
 objdef Indent offset = newIndent(0);
 

--- a/src/utrace/UTrace.sac
+++ b/src/utrace/UTrace.sac
@@ -14,12 +14,7 @@ use Indent: all;
 
 export all except { offset, whitespace, printSeparator, printHeader };
 
-#define BUILT_IN(fun)                                                          \
-fun(int)                                                                       \
-fun(float)                                                                     \
-fun(double)                                                                    \
-fun(bool)                                                                      \
-fun(char)
+#include "builtin.mac"
 
 objdef Indent offset = newIndent(0);
 
@@ -43,8 +38,8 @@ void printHeader(string modName, int line)
 
 /******************************************************************************/
 
-#define SHOW(a)                                                                \
-void indentedShow(a[d:shp] arr)                                                \
+#define SHOW(typ, postfix, zero, one)                                          \
+void indentedShow(typ[d:shp] arr)                                              \
 {                                                                              \
     cshape = to_string(format(shp));                                           \
     printf("reshape([ %s ] , [\n", cshape);                                    \
@@ -68,7 +63,7 @@ void indentedShow(a[d:shp] arr)                                                \
     decIndent(offset, _add_SxS_(strlen(cshape), 16));                          \
 }                                                                              \
                                                                                \
-void indentedShow(a[.,.] arr)                                                  \
+void indentedShow(typ[.,.] arr)                                                \
 {                                                                              \
     spaces = whitespace(_add_SxS_(getIndent(), getIndent(offset)));            \
                                                                                \
@@ -79,12 +74,12 @@ void indentedShow(a[.,.] arr)                                                  \
     ArrayIO::show(ext_carr);                                                   \
 }                                                                              \
                                                                                \
-void indentedShow(a[.] arr)                                                    \
+void indentedShow(typ[.] arr)                                                  \
 {                                                                              \
     ArrayIO::show(arr);                                                        \
 }                                                                              \
                                                                                \
-void indentedShow(a arr)                                                       \
+void indentedShow(typ arr)                                                     \
 {                                                                              \
     ScalarIO::show(arr);                                                       \
 }
@@ -116,8 +111,8 @@ void PrintArgsDone(string modName, int line, string funName)
     printf(");\n");
 }
 
-#define PRINT_ARG(a)                                                           \
-void PrintArg(string modName, int line, string var, a[*] arr)                  \
+#define PRINT_ARG(typ, postfix, zero, one)                                     \
+void PrintArg(string modName, int line, string var, typ[*] arr)                \
 {                                                                              \
     doIndent("   ");                                                           \
     doIndent(offset, " ");                                                     \
@@ -129,8 +124,8 @@ void PrintArg(string modName, int line, string var, a[*] arr)                  \
 
 BUILT_IN(PRINT_ARG)
 
-#define PRINT_ASSIGN(a)                                                        \
-void PrintAssign(string modName, int line, string var, a[*] arr)               \
+#define PRINT_ASSIGN(typ, postfix, zero, one)                                  \
+void PrintAssign(string modName, int line, string var, typ[*] arr)             \
 {                                                                              \
     printHeader(modName, line);                                                \
     printf("%s = ", var);                                                      \
@@ -141,8 +136,8 @@ void PrintAssign(string modName, int line, string var, a[*] arr)               \
 
 BUILT_IN(PRINT_ASSIGN)
 
-#define PRINT_RETURN(a)                                                        \
-void PrintReturn(string modName, int line, a[*] arr)                           \
+#define PRINT_RETURN(typ, postfix, zero, one)                                  \
+void PrintReturn(string modName, int line, typ[*] arr)                         \
 {                                                                              \
     printHeader(modName, line);                                                \
     printf("returning ");                                                      \

--- a/src/utrace/UTrace.sac
+++ b/src/utrace/UTrace.sac
@@ -43,7 +43,7 @@ void printHeader(string modName, int line)
 
 /******************************************************************************/
 
-#define SHOW(typ, postfix, zero, one)                                          \
+#define SHOW(typ)                                                              \
 void indentedShow(typ[d:shp] arr)                                              \
 {                                                                              \
     cshape = to_string(format(shp));                                           \
@@ -116,7 +116,7 @@ void PrintArgsDone(string modName, int line, string funName)
     printf(");\n");
 }
 
-#define PRINT_ARG(typ, postfix, zero, one)                                     \
+#define PRINT_ARG(typ)                                                         \
 void PrintArg(string modName, int line, string var, typ[*] arr)                \
 {                                                                              \
     doIndent("   ");                                                           \
@@ -129,7 +129,7 @@ void PrintArg(string modName, int line, string var, typ[*] arr)                \
 
 BUILT_IN(PRINT_ARG)
 
-#define PRINT_ASSIGN(typ, postfix, zero, one)                                  \
+#define PRINT_ASSIGN(typ)                                                      \
 void PrintAssign(string modName, int line, string var, typ[*] arr)             \
 {                                                                              \
     printHeader(modName, line);                                                \
@@ -141,7 +141,7 @@ void PrintAssign(string modName, int line, string var, typ[*] arr)             \
 
 BUILT_IN(PRINT_ASSIGN)
 
-#define PRINT_RETURN(typ, postfix, zero, one)                                  \
+#define PRINT_RETURN(typ)                                                      \
 void PrintReturn(string modName, int line, typ[*] arr)                         \
 {                                                                              \
     printHeader(modName, line);                                                \


### PR DESCRIPTION
Some files use `Templates.mac` even though really they only require `BUILT_IN`.

This reduces some of that coupling.