### PR TITLE
POSIX guarantees that CLOCK_REALTIME exists; no need to check for it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,13 @@ PROJECT (sac-stdlib)
 #             automatically pull sac2c compiler.
 
 # Where the compiled sac modules result
-SET (DLL_BUILD_DIR  "${PROJECT_BINARY_DIR}/lib")
+SET (DLL_BUILD_DIR "${PROJECT_BINARY_DIR}/lib")
 
 # For what targets we build modules
-SET (TARGETS            seq seq_checks mt_pth CACHE STRING "Build stdlib for these targets")
-SET (SAC2C_EXEC                     CACHE STRING "A path to sac2c compiler")
-SET (LINKSETSIZE        "500"       CACHE STRING "Set a value for -linksetsize parameter of sac2c")
-SET (IS_RELEASE         FALSE       CACHE BOOL "Indicate if we are building with release version of SAC2C")
+SET (TARGETS     seq seq_checks mt_pth CACHE STRING "Build stdlib for these targets")
+SET (SAC2C_EXEC                        CACHE STRING "A path to sac2c compiler")
+SET (LINKSETSIZE "500"                 CACHE STRING "Set a value for -linksetsize parameter of sac2c")
+SET (IS_RELEASE  FALSE                 CACHE BOOL "Indicate if we are building with release version of SAC2C")
 
 SET (SAC2C_EXTRA_INC
      -DHAVE_CONFIG_H
@@ -55,11 +55,8 @@ IF (BUILD_EXT)
 ENDIF ()
 
 # For every target run CMakeLists.txt in src
-SET (TARGET_COUNT 1)
 FOREACH (TARGET IN ITEMS ${TARGETS})
-    #MESSAGE ("target #${TARGET_COUNT} = ${TARGET}")
-    ADD_SUBDIRECTORY (src   src-${TARGET})
-    MATH (EXPR TARGET_COUNT "${TARGET_COUNT} + 1")
+    ADD_SUBDIRECTORY (src src-${TARGET})
 ENDFOREACH ()
 
 # This build target is responsible for generating the package sac2crc file

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -4,21 +4,9 @@ INCLUDE (CheckLibraryExists)
 INCLUDE (CheckIncludeFiles)
 INCLUDE ("cmake/options.cmake")
 
-# Additional config checks regarding feature support
-INCLUDE ("cmake-common/check-sac2c-feature-support.cmake")
-
 # Check for flex/bison
-FIND_PACKAGE (BISON  REQUIRED)
-FIND_PACKAGE (FLEX  REQUIRED)
-
-# Check mkdtemp exists
-CHECK_FUNCTION_EXISTS (mkdtemp HAVE_MKDTEMP)
-
-# Check if we support SAC2C header pragma
-CHECK_SAC2C_SUPPORT_HEADER_PRAGMA ()
-
-CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
-                "${PROJECT_BINARY_DIR}/include/config.h")
+FIND_PACKAGE (BISON REQUIRED)
+FIND_PACKAGE (FLEX REQUIRED)
 
 MESSAGE ("
  * Stdlib configuration done.

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -44,7 +44,6 @@ IF (NOT POW_WORKS)
 ENDIF ()
 
 SET (NEED_LIBRT)
-SET (HAVE_GETTIME_REALTIME 1)
 SET (LIBRT_TEST_PROG "
 #include <time.h>
 #include <sys/times.h>
@@ -64,27 +63,8 @@ IF (NOT RT_WORKS)
     SET (CMAKE_REQUIRED_LIBRARIES ${OLD_FLAGS})
     IF (RT_WORKS)
         SET (NEED_LIBRT 1)
-    ELSE ()
-        SET (HAVE_GETTIME_REALTIME 0)
     ENDIF ()
 ENDIF ()
-
-
-CHECK_C_SOURCE_COMPILES ("
-#include <time.h>
-#include <mach/clock.h>
-#include <mach/mach.h>
-int main (void) {
-  struct timespec ts;
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service (mach_host_self(), CALENDAR_CLOCK, &cclock);
-  clock_get_time (cclock, &mts);
-  mach_port_deallocate (mach_task_self(), cclock);
-  ts.tv_sec = mts.tv_sec;
-  ts.tv_nsec = mts.tv_nsec;
-"
-HAVE_MACH_CLOCK_GET_TIME)
 
 CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
                 "${PROJECT_BINARY_DIR}/include/config.h")
@@ -99,8 +79,6 @@ MESSAGE ("
  * sac2c extra flags:      ${SAC2C_EXTRA_INC}
  *
  * Configuration state:
- * - realtime clock:       ${HAVE_GETTIME_REALTIME}
- * - mach clock:           ${HAVE_MACH_CLOCK_GET_TIME}
  * - full types:           ${FULLTYPES}
  * - build generic         ${BUILDGENERIC}
  * - build extended:       ${BUILD_EXT}

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -17,32 +17,6 @@ CHECK_FUNCTION_EXISTS (mkdtemp HAVE_MKDTEMP)
 # Check if we support SAC2C header pragma
 CHECK_SAC2C_SUPPORT_HEADER_PRAGMA ()
 
-# Check whether we have/need -lm
-SET (NEED_LIBM)
-SET (LIB_M_SRC "
-#include <math.h>
-
-int main(void) {
-    return pow (3, 1.4);
-}
-")
-
-CHECK_C_SOURCE_COMPILES ("${LIB_M_SRC}"   POW_WORKS)
-IF (NOT POW_WORKS)
-    UNSET (POW_WORKS)
-    SET (OLD_FLAGS ${CMAKE_REQUIRED_LIBRARIES})
-    LIST (APPEND CMAKE_REQUIRED_LIBRARIES m)
-    CHECK_C_SOURCE_COMPILES ("${LIB_M_SRC}" POW_WORKS)
-    SET (CMAKE_REQUIRED_LIBRARIES ${OLD_FLAGS})
-    IF (POW_WORKS)
-        SET (NEED_LIBM 1)
-    ELSE ()
-        MESSAGE (FATAL_ERROR
-                 "Failed to compile math function `pow', "
-                 "both with and without -lm")
-    ENDIF ()
-ENDIF ()
-
 CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
                 "${PROJECT_BINARY_DIR}/include/config.h")
 

--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -43,29 +43,6 @@ IF (NOT POW_WORKS)
     ENDIF ()
 ENDIF ()
 
-SET (NEED_LIBRT)
-SET (LIBRT_TEST_PROG "
-#include <time.h>
-#include <sys/times.h>
-int main (void) {
- struct timespec ts;
- clock_gettime (CLOCK_REALTIME, &ts);
- return 0;
-}
-")
-
-CHECK_C_SOURCE_COMPILES ("${LIBRT_TEST_PROG}"   RT_WORKS)
-IF (NOT RT_WORKS)
-    UNSET (RT_WORKS)
-    SET (OLD_FLAGS ${CMAKE_REQUIRED_LIBRARIES})
-    LIST (APPEND CMAKE_REQUIRED_LIBRARIES rt)
-    CHECK_C_SOURCE_COMPILES ("${LIBRT_TEST_PROG}"   RT_WORKS)
-    SET (CMAKE_REQUIRED_LIBRARIES ${OLD_FLAGS})
-    IF (RT_WORKS)
-        SET (NEED_LIBRT 1)
-    ENDIF ()
-ENDIF ()
-
 CONFIGURE_FILE ("${PROJECT_SOURCE_DIR}/cmake/config.h.in"
                 "${PROJECT_BINARY_DIR}/include/config.h")
 

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,8 +1,3 @@
-/* Real time libraries.  */
-#cmakedefine HAVE_GETTIME_REALTIME
-
-#cmakedefine HAVE_MACH_CLOCK_GET_TIME
-
 /* `mkdtemp' function */
 #cmakedefine HAVE_MKDTEMP
 

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -4,8 +4,5 @@
 /* Do we need to link with -lm.  */
 #cmakedefine NEED_LIBM
 
-/* Do we need to link with -lrt.  */
-#cmakedefine NEED_LIBRT
-
 /* Support sac2c #pragma header feature */
 #cmakedefine HAVE_HEADER_PRAGMA

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,8 +1,5 @@
 /* `mkdtemp' function */
 #cmakedefine HAVE_MKDTEMP
 
-/* Do we need to link with -lm.  */
-#cmakedefine NEED_LIBM
-
 /* Support sac2c #pragma header feature */
 #cmakedefine HAVE_HEADER_PRAGMA

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -1,5 +1,0 @@
-/* `mkdtemp' function */
-#cmakedefine HAVE_MKDTEMP
-
-/* Support sac2c #pragma header feature */
-#cmakedefine HAVE_HEADER_PRAGMA

--- a/cmake/sac-core-ext.txt
+++ b/cmake/sac-core-ext.txt
@@ -9,7 +9,7 @@
 
 # Auxiliary
 auxiliary/Benchmarking.sac                 Ext
-auxiliary/Hiding.xsac                       Ext
+auxiliary/Hiding.xsac                      Ext
 auxiliary/Interval.sac                     Ext
 
 # Numerical

--- a/src/stdio/src/FibreIO/FibreScan.y
+++ b/src/stdio/src/FibreIO/FibreScan.y
@@ -5,17 +5,6 @@ extern char yytext[];
 
 #include <stdio.h>
 #include "FibreScan.h"
-/* sac.h unfortunately exports the following symbols, causing a redefinition
- * warning when import config.h, so undefine them to silence the warnings.
- */
-#undef ARCH
-#undef PACKAGE_NAME
-#undef PACKAGE_STRING
-#undef PACKAGE_TARNAME
-#undef PACKAGE_VERSION
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 
 enum READMODE {
   byte_mode,
@@ -115,7 +104,7 @@ extern int yynerrs;
        PARSE_UBYTE PARSE_USHORT PARSE_UINT PARSE_ULONG PARSE_ULONGLONG
        PARSE_DOUBLE_ARRAY PARSE_FLOAT_ARRAY PARSE_STRING_ARRAY
        PARSE_BYTE_ARRAY PARSE_SHORT_ARRAY PARSE_INT_ARRAY PARSE_LONG_ARRAY
-       PARSE_LONGLONG_ARRAY PARSE_UBYTE_ARRAY PARSE_USHORT_ARRAY 
+       PARSE_LONGLONG_ARRAY PARSE_UBYTE_ARRAY PARSE_USHORT_ARRAY
        PARSE_UINT_ARRAY PARSE_ULONG_ARRAY PARSE_ULONGLONG_ARRAY
 %token SQBR_L SQBR_R COLON COMMA TTRUE TFALSE
 %token <cbyte>  NUMBYTE
@@ -161,99 +150,99 @@ extern YYSTYPE yylval;
 %%
 
 
-file: PARSE_BOOL bool 
+file: PARSE_BOOL bool
          {boolval = $2; return(0);}
-    | PARSE_BYTE  NUMBYTE 
-         {byteval = $2; return(0);} 
-    | PARSE_SHORT  NUMSHORT 
-         {shortval = $2; return(0);} 
-    | PARSE_INT  NUM 
-         {intval = $2; return(0);} 
-    | PARSE_LONG  NUMLONG 
-         {longval = $2; return(0);} 
-    | PARSE_LONGLONG  NUMLONGLONG 
-         {longlongval = $2; return(0);} 
-    | PARSE_UBYTE  NUMUBYTE 
-         {ubyteval = $2; return(0);} 
-    | PARSE_USHORT  NUMUSHORT 
-         {ushortval = $2; return(0);} 
-    | PARSE_UINT  NUMUINT 
-         {uintval = $2; return(0);} 
-    | PARSE_ULONG  NUMULONG 
-         {ulongval = $2; return(0);} 
-    | PARSE_ULONGLONG  NUMULONGLONG 
-         {ulonglongval = $2; return(0);} 
-    | PARSE_FLOAT FLOAT 
+    | PARSE_BYTE  NUMBYTE
+         {byteval = $2; return(0);}
+    | PARSE_SHORT  NUMSHORT
+         {shortval = $2; return(0);}
+    | PARSE_INT  NUM
+         {intval = $2; return(0);}
+    | PARSE_LONG  NUMLONG
+         {longval = $2; return(0);}
+    | PARSE_LONGLONG  NUMLONGLONG
+         {longlongval = $2; return(0);}
+    | PARSE_UBYTE  NUMUBYTE
+         {ubyteval = $2; return(0);}
+    | PARSE_USHORT  NUMUSHORT
+         {ushortval = $2; return(0);}
+    | PARSE_UINT  NUMUINT
+         {uintval = $2; return(0);}
+    | PARSE_ULONG  NUMULONG
+         {ulongval = $2; return(0);}
+    | PARSE_ULONGLONG  NUMULONGLONG
+         {ulonglongval = $2; return(0);}
+    | PARSE_FLOAT FLOAT
          {floatval = $2; return(0);}
-    | PARSE_STRING STRING 
+    | PARSE_STRING STRING
          {stringval = $2; return(0);}
-    | PARSE_DOUBLE DOUBLE 
+    | PARSE_DOUBLE DOUBLE
          {doubleval = $2; return(0);}
-    | PARSE_DOUBLE_ARRAY 
-         {got_scalar = 0; mode = double_mode;} 
-         parse_array 
+    | PARSE_DOUBLE_ARRAY
+         {got_scalar = 0; mode = double_mode;}
+         parse_array
          {return(0);}
-    | PARSE_FLOAT_ARRAY 
-         {got_scalar = 0; mode = float_mode;} 
-         parse_array 
+    | PARSE_FLOAT_ARRAY
+         {got_scalar = 0; mode = float_mode;}
+         parse_array
          {return(0);}
-    | PARSE_BYTE_ARRAY 
-         {got_scalar = 0; mode = byte_mode;} 
-         parse_array 
+    | PARSE_BYTE_ARRAY
+         {got_scalar = 0; mode = byte_mode;}
+         parse_array
          {return(0);}
-    | PARSE_SHORT_ARRAY 
-         {got_scalar = 0; mode = short_mode;} 
-         parse_array 
+    | PARSE_SHORT_ARRAY
+         {got_scalar = 0; mode = short_mode;}
+         parse_array
          {return(0);}
-    | PARSE_INT_ARRAY 
-         {got_scalar = 0; mode = int_mode;} 
-         parse_array 
+    | PARSE_INT_ARRAY
+         {got_scalar = 0; mode = int_mode;}
+         parse_array
          {return(0);}
-    | PARSE_LONG_ARRAY 
-         {got_scalar = 0; mode = long_mode;} 
-         parse_array 
+    | PARSE_LONG_ARRAY
+         {got_scalar = 0; mode = long_mode;}
+         parse_array
          {return(0);}
-    | PARSE_LONGLONG_ARRAY 
-         {got_scalar = 0; mode = longlong_mode;} 
-         parse_array 
+    | PARSE_LONGLONG_ARRAY
+         {got_scalar = 0; mode = longlong_mode;}
+         parse_array
          {return(0);}
-    | PARSE_UBYTE_ARRAY 
-         {got_scalar = 0; mode = ubyte_mode;} 
-         parse_array 
+    | PARSE_UBYTE_ARRAY
+         {got_scalar = 0; mode = ubyte_mode;}
+         parse_array
          {return(0);}
-    | PARSE_USHORT_ARRAY 
-         {got_scalar = 0; mode = ushort_mode;} 
-         parse_array 
+    | PARSE_USHORT_ARRAY
+         {got_scalar = 0; mode = ushort_mode;}
+         parse_array
          {return(0);}
-    | PARSE_UINT_ARRAY 
-         {got_scalar = 0; mode = uint_mode;} 
-         parse_array 
+    | PARSE_UINT_ARRAY
+         {got_scalar = 0; mode = uint_mode;}
+         parse_array
          {return(0);}
-    | PARSE_ULONG_ARRAY 
-         {got_scalar = 0; mode = ulong_mode;} 
-         parse_array 
+    | PARSE_ULONG_ARRAY
+         {got_scalar = 0; mode = ulong_mode;}
+         parse_array
          {return(0);}
-    | PARSE_ULONGLONG_ARRAY 
-         {got_scalar = 0; mode = ulonglong_mode;} 
-         parse_array 
+    | PARSE_ULONGLONG_ARRAY
+         {got_scalar = 0; mode = ulonglong_mode;}
+         parse_array
          {return(0);}
-    | PARSE_STRING_ARRAY 
-         {got_scalar = 0; mode = string_mode;} 
-         parse_array 
+    | PARSE_STRING_ARRAY
+         {got_scalar = 0; mode = string_mode;}
+         parse_array
          {return(0);}
     ;
 
 
-parse_array: {dims=0; 
+parse_array: {dims=0;
               dim_pos=-1;
               array_pos=0;
               size_fixed=0;
-             } 
+             }
              array { return(0);}
-           | parse_scalar 
+           | parse_scalar
            ;
 
-parse_scalar: NUM 
+parse_scalar: NUM
                 { if( mode == double_mode) {
                     doublearray = (double *) SAC_MALLOC( sizeof( double));
                     *doublearray = $1;
@@ -266,133 +255,133 @@ parse_scalar: NUM
                     intarray = (int *) SAC_MALLOC( sizeof( int));
                     *intarray = $1;
                   }
-                  else { 
+                  else {
                     yyerror( "numeric type expected!");
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMBYTE
-                { if( mode != byte_mode) { 
+                { if( mode != byte_mode) {
                     yyerror( "byte numeric expected!");
                   }
                   else {
                     bytearray = (char *) SAC_MALLOC( sizeof( char));
                     *bytearray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMSHORT
-                { if(  mode != short_mode) { 
+                { if(  mode != short_mode) {
                     yyerror( "short numeric expected!");
                   }
                   else {
                     shortarray = (short *) SAC_MALLOC( sizeof( short));
                     *shortarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMLONG
-                { if( mode != long_mode) { 
+                { if( mode != long_mode) {
                     yyerror( "long numeric expected!");
                   }
                   else {
                     longarray = (long *) SAC_MALLOC( sizeof( long));
                     *longarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMLONGLONG
-                { if( mode != longlong_mode) { 
+                { if( mode != longlong_mode) {
                     yyerror( "longlong numeric expected!");
                   }
                   else {
-                    longlongarray = 
+                    longlongarray =
 		    (long long*) SAC_MALLOC( sizeof( long long));
                     *longlongarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMUBYTE
-                { if( mode != ubyte_mode) { 
+                { if( mode != ubyte_mode) {
                     yyerror( "ubyte numeric expected!");
                   }
                   else {
-                    ubytearray = 
+                    ubytearray =
 		    (unsigned char *) SAC_MALLOC( sizeof( unsigned char));
                     *ubytearray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMUSHORT
-                { if( mode != ushort_mode) { 
+                { if( mode != ushort_mode) {
                     yyerror( "ushort numeric expected!");
                   }
                   else {
-                    ushortarray = 
+                    ushortarray =
 		    (unsigned short *) SAC_MALLOC( sizeof( unsigned short));
                     *ushortarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMUINT
-                { if( mode != uint_mode) { 
+                { if( mode != uint_mode) {
                     yyerror( "uint numeric expected!");
                   }
                   else {
-                    uintarray = 
+                    uintarray =
 		    (unsigned int *) SAC_MALLOC( sizeof( unsigned int));
                     *uintarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMULONG
-                { if( mode != ulong_mode) { 
+                { if( mode != ulong_mode) {
                     yyerror( "ulong numeric expected!");
                   }
                   else {
-                    ulongarray = 
+                    ulongarray =
 		    (unsigned long *) SAC_MALLOC( sizeof( unsigned long));
                     *ulongarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | NUMULONGLONG
-                { if( mode != ulonglong_mode) { 
+                { if( mode != ulonglong_mode) {
                     yyerror( "ulonglong numeric expected!");
                   }
                   else {
-                    ulonglongarray = (unsigned long long*) 
+                    ulonglongarray = (unsigned long long*)
 		    SAC_MALLOC( sizeof( unsigned long long));
                     *ulonglongarray = $1;
                   }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  dims = 0;
                  size = 1;
                 }
             | DOUBLE
                 {if( ( mode != float_mode) &&
-                     ( mode != double_mode)) { 
+                     ( mode != double_mode)) {
                    yyerror( "Unexpected floating point read!\n");
                  }
-                 got_scalar = 1; 
+                 got_scalar = 1;
                  switch( mode) {
                    case float_mode:
                      floatarray = (float *) SAC_MALLOC( sizeof( float));
@@ -407,15 +396,15 @@ parse_scalar: NUM
                      size = 1;
                      break;
                    case int_mode:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed double where int was expected");
                      break;
                    case string_mode:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed double where string was expected");
                      break;
                    default:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed double where numeric was expected");
                      break;
                  }
@@ -433,19 +422,19 @@ parse_scalar: NUM
                       size = 1;
                       break;
                    case int_mode:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed string where int was expected");
                      break;
                    case double_mode:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed string where double was expected");
                      break;
                    case float_mode:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed string where float was expected");
                      break;
                    default:
-                     yyerror( 
+                     yyerror(
                        "Incorrectly parsed double where numeric was expected");
                      break;
                   }
@@ -457,7 +446,7 @@ bool: TTRUE {$$ = 1;}
 
 
 
-arrays: array 
+arrays: array
         { if( size_fixed) {
             if( elems_left[ dim_pos] == 0) {
               yyerror("more sub-arrays than specified!");
@@ -508,27 +497,27 @@ array: SQBR_L desc COLON
                longarray = (long *) SAC_MALLOC( size * sizeof( long));
                break;
              case longlong_mode:
-               longlongarray = (long long *) 
+               longlongarray = (long long *)
 	       SAC_MALLOC( size * sizeof( long long));
                break;
              case ubyte_mode:
-               ubytearray = (unsigned char *) 
+               ubytearray = (unsigned char *)
 	       SAC_MALLOC( size * sizeof( unsigned char));
                break;
              case ushort_mode:
-               ushortarray = (unsigned short *) 
+               ushortarray = (unsigned short *)
 	       SAC_MALLOC( size * sizeof( unsigned short));
                break;
              case uint_mode:
-               uintarray = (unsigned int *) 
+               uintarray = (unsigned int *)
 	       SAC_MALLOC( size * sizeof( unsigned int));
                break;
              case ulong_mode:
-               ulongarray = (unsigned long *) 
+               ulongarray = (unsigned long *)
 	       SAC_MALLOC( size * sizeof( unsigned long));
                break;
              case ulonglong_mode:
-               ulonglongarray = (unsigned long long *) 
+               ulonglongarray = (unsigned long long *)
 	       SAC_MALLOC( size * sizeof( unsigned long long));
                break;
              case float_mode:
@@ -568,12 +557,12 @@ elems: elems elem
          }
          elems_left[ dim_pos]--;
          array_pos++;
-       } 
+       }
     | /* empty */
     ;
 
-elem: NUM 
-      { if( mode == double_mode) { 
+elem: NUM
+      { if( mode == double_mode) {
           doublearray[ array_pos]= (double)$1;
         }
         else if( mode == float_mode) {
@@ -587,7 +576,7 @@ elem: NUM
         }
       }
     | NUMBYTE
-	{ if( mode != byte_mode) { 
+	{ if( mode != byte_mode) {
 	    yyerror( "byte array element expected!");
 	  }
 	  else {
@@ -595,7 +584,7 @@ elem: NUM
 	  }
 	}
     | NUMSHORT
-	{ if( mode != short_mode) { 
+	{ if( mode != short_mode) {
 	    yyerror( "short array element expected!");
 	  }
 	  else {
@@ -603,7 +592,7 @@ elem: NUM
 	  }
 	}
     | NUMLONG
-	{ if( mode != long_mode) { 
+	{ if( mode != long_mode) {
 	    yyerror( "long array element expected!");
 	  }
 	  else {
@@ -611,7 +600,7 @@ elem: NUM
 	  }
 	}
     | NUMLONGLONG
-	{ if( mode != longlong_mode) { 
+	{ if( mode != longlong_mode) {
 	    yyerror( "longlong array element expected!");
 	  }
 	  else {
@@ -619,7 +608,7 @@ elem: NUM
 	  }
 	}
     | NUMUBYTE
-	{ if( mode != ubyte_mode) { 
+	{ if( mode != ubyte_mode) {
 	    yyerror( "ubyte array element expected!");
 	  }
 	  else {
@@ -627,7 +616,7 @@ elem: NUM
 	  }
 	}
     | NUMUSHORT
-	{ if( mode != ushort_mode) { 
+	{ if( mode != ushort_mode) {
 	    yyerror( "ushort array element expected!");
 	  }
 	  else {
@@ -635,7 +624,7 @@ elem: NUM
 	  }
 	}
     | NUMUINT
-	{ if( mode != uint_mode) { 
+	{ if( mode != uint_mode) {
 	    yyerror( "uint array element expected!");
 	  }
 	  else {
@@ -643,7 +632,7 @@ elem: NUM
 	  }
 	}
     | NUMULONG
-	{ if( mode != ulong_mode) { 
+	{ if( mode != ulong_mode) {
 	    yyerror( "ulong array element expected!");
 	  }
 	  else {
@@ -651,25 +640,25 @@ elem: NUM
 	  }
 	}
     | NUMULONGLONG
-	{ if( mode != ulonglong_mode) { 
+	{ if( mode != ulonglong_mode) {
 	    yyerror( "ulonglong array element expected!");
 	  }
 	  else {
 	    ulonglongarray[ array_pos]=$1;
 	  }
 	}
-    | DOUBLE  
+    | DOUBLE
       { if( mode == float_mode) {
           floatarray[ array_pos] = (float)$1;
         }
-        else if( mode == double_mode) { 
+        else if( mode == double_mode) {
           doublearray[ array_pos] = $1;
         }
         else {
           yyerror( "Unexpected floating point read\n");
         }
       }
-    | STRING  
+    | STRING
       { if( mode == string_mode) {
           stringarray[ array_pos] = $1;
         }

--- a/src/system/MTClock.sac
+++ b/src/system/MTClock.sac
@@ -1,7 +1,3 @@
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 class MTClock;
 
 external classtype;
@@ -15,9 +11,6 @@ external MTClock createTheMTClock();
     #pragma linkobj "src/MTClock/mtclock.o"
     #pragma effect World::TheWorld
     #pragma linksign [1]
-#ifdef NEED_LIBRT
-    #pragma linkwith "rt"
-#endif
 
 external void touch(MTClock& mtclock);
     #pragma linkname "SAC_MTClock_touch"

--- a/src/system/RTClock.sac
+++ b/src/system/RTClock.sac
@@ -11,9 +11,6 @@ external RTClock createTheRTClock();
     #pragma linkname "SAC_RTClock_createTheRTClock"
     #pragma linkobj "src/RTClock/rtclock.o"
     #pragma linksign [1]
-#ifdef NEED_LIBRT
-    #pragma linkwith "rt"
-#endif
 
 external void touch(RTClock &rtclock);
     #pragma linkname "SAC_RTClock_touch"

--- a/src/system/RTClock.sac
+++ b/src/system/RTClock.sac
@@ -1,40 +1,26 @@
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 class RTClock;
 
 external classtype;
 
-#if defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
-export {TheRTClock,touch,gettime};
-
-#else //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
-export {TheRTClock,touch};
-
-#endif //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
+export { TheRTClock, touch, gettime };
 
 objdef RTClock TheRTClock = createTheRTClock();
 
-external RTClock createTheRTClock( );
-#pragma effect World::TheWorld
-#pragma linkname "SAC_RTClock_createTheRTClock"
-#pragma linkobj "src/RTClock/rtclock.o"
-#pragma linksign [1]
+external RTClock createTheRTClock();
+    #pragma effect World::TheWorld
+    #pragma linkname "SAC_RTClock_createTheRTClock"
+    #pragma linkobj "src/RTClock/rtclock.o"
+    #pragma linksign [1]
 #ifdef NEED_LIBRT
-#pragma linkwith "rt"
+    #pragma linkwith "rt"
 #endif
 
-external void touch( RTClock &rtclock);
-#pragma linkname "SAC_RTClock_touch"
-#pragma linkobj "src/RTClock/rtclock.o"
+external void touch(RTClock &rtclock);
+    #pragma linkname "SAC_RTClock_touch"
+    #pragma linkobj "src/RTClock/rtclock.o"
 
-#if defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
 external long, long gettime();
-#pragma effect  RTClock::TheRTClock  
-#pragma linkname "SAC_RTClock_gettime"
-#pragma linkobj "src/RTClock/rtclock.o"
-#pragma linksign [1,2]
-
-#endif //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
-
+    #pragma effect RTClock::TheRTClock
+    #pragma linkname "SAC_RTClock_gettime"
+    #pragma linkobj "src/RTClock/rtclock.o"
+    #pragma linksign [1,2]

--- a/src/system/RTimer.sac
+++ b/src/system/RTimer.sac
@@ -1,68 +1,42 @@
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 class RTimer;
+
 external classtype;
 
 use RTClock: all;
 
 export all;
 
-external RTimer createRTimer( );
-#pragma effect RTClock::TheRTClock
-#pragma linkname "SAC_RTimer_createRTimer"
-#pragma linkobj "src/RTimer/rtimer.o"
-#pragma linksign [1]
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external RTimer createRTimer();
+    #pragma linkname "SAC_RTimer_createRTimer"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma effect RTClock::TheRTClock
+    #pragma linksign [1]
 
-external void destroyRTimer( RTimer rtimer);
-#pragma effect RTClock::TheRTClock
-#pragma linkname "SAC_RTimer_destroyRTimer"
-#pragma linkobj "src/RTimer/rtimer.o"
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external void destroyRTimer(RTimer rtimer);
+    #pragma linkname "SAC_RTimer_destroyRTimer"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma effect RTClock::TheRTClock
 
-external void startRTimer( RTimer &rtimer);
-#pragma effect RTClock::TheRTClock
-#pragma linkname "SAC_RTimer_startRTimer"
-#pragma linkobj "src/RTimer/rtimer.o"
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external void startRTimer(RTimer &rtimer);
+    #pragma linkname "SAC_RTimer_startRTimer"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma effect RTClock::TheRTClock
 
-external void stopRTimer( RTimer &rtimer);
-#pragma effect RTClock::TheRTClock
-#pragma linkname "SAC_RTimer_stopRTimer"
-#pragma linkobj "src/RTimer/rtimer.o"
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external void stopRTimer(RTimer &rtimer);
+    #pragma linkname "SAC_RTimer_stopRTimer"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma effect RTClock::TheRTClock
 
-external void resetRTimer( RTimer &rtimer);
-#pragma linkname "SAC_RTimer_resetRTimer"
-#pragma linkobj "src/RTimer/rtimer.o"
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external void resetRTimer(RTimer &rtimer);
+    #pragma linkname "SAC_RTimer_resetRTimer"
+    #pragma linkobj "src/RTimer/rtimer.o"
 
-external int, int getRTimerInts( RTimer &rtimer);
-#pragma linkname "SAC_RTimer_getRTimerInts"
-#pragma linkobj "src/RTimer/rtimer.o"
-#pragma linksign [2,3,1]
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
+external int, int getRTimerInts(RTimer &rtimer);
+    #pragma linkname "SAC_RTimer_getRTimerInts"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma linksign [2,3,1]
 
-external double getRTimerDbl( RTimer &rtimer);
-#pragma linkname "SAC_RTimer_getRTimerDbl"
-#pragma linkobj "src/RTimer/rtimer.o"
-#pragma linksign [0,1]
-#ifdef NEED_LIBRT
-  #pragma linkwith "rt"
-#endif
-
-
+external double getRTimerDbl(RTimer &rtimer);
+    #pragma linkname "SAC_RTimer_getRTimerDbl"
+    #pragma linkobj "src/RTimer/rtimer.o"
+    #pragma linksign [0,1]

--- a/src/system/RTimer.sac
+++ b/src/system/RTimer.sac
@@ -2,30 +2,30 @@ class RTimer;
 
 external classtype;
 
-use RTClock: all;
+use RTClock: { TheRTClock };
 
 export all;
 
 external RTimer createRTimer();
     #pragma linkname "SAC_RTimer_createRTimer"
     #pragma linkobj "src/RTimer/rtimer.o"
-    #pragma effect RTClock::TheRTClock
+    #pragma effect TheRTClock
     #pragma linksign [1]
 
 external void destroyRTimer(RTimer rtimer);
     #pragma linkname "SAC_RTimer_destroyRTimer"
     #pragma linkobj "src/RTimer/rtimer.o"
-    #pragma effect RTClock::TheRTClock
+    #pragma effect TheRTClock
 
 external void startRTimer(RTimer &rtimer);
     #pragma linkname "SAC_RTimer_startRTimer"
     #pragma linkobj "src/RTimer/rtimer.o"
-    #pragma effect RTClock::TheRTClock
+    #pragma effect TheRTClock
 
 external void stopRTimer(RTimer &rtimer);
     #pragma linkname "SAC_RTimer_stopRTimer"
     #pragma linkobj "src/RTimer/rtimer.o"
-    #pragma effect RTClock::TheRTClock
+    #pragma effect TheRTClock
 
 external void resetRTimer(RTimer &rtimer);
     #pragma linkname "SAC_RTimer_resetRTimer"

--- a/src/system/RTimer.sac
+++ b/src/system/RTimer.sac
@@ -26,8 +26,6 @@ external void destroyRTimer( RTimer rtimer);
   #pragma linkwith "rt"
 #endif
 
-#if defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
-
 external void startRTimer( RTimer &rtimer);
 #pragma effect RTClock::TheRTClock
 #pragma linkname "SAC_RTimer_startRTimer"
@@ -43,8 +41,6 @@ external void stopRTimer( RTimer &rtimer);
 #ifdef NEED_LIBRT
   #pragma linkwith "rt"
 #endif
-
-#endif //defined(HAVE_GETTIME_REALTIME) || defined(HAVE_MACH_CLOCK_GET_TIME)
 
 external void resetRTimer( RTimer &rtimer);
 #pragma linkname "SAC_RTimer_resetRTimer"

--- a/src/system/src/RTClock/rtclock.c
+++ b/src/system/src/RTClock/rtclock.c
@@ -1,63 +1,47 @@
-/*
- * $Id$
+/******************************************************************************
  *
- * Description:
+ * @file rtclock.c
  *
- * This module implements the functionally sound integration of the real
- * time clock into the world of SAC.
- */
-
+ * @brief This module implements the functionally sound integration of the
+ * real time clock into the world of SAC.
+ *
+ ******************************************************************************/
 #include <time.h>
-#include "libsac/essentials/message.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#ifdef HAVE_GETTIME_REALTIME
-#include <sys/times.h>
-#elif HAVE_MACH_CLOCK_GET_TIME
+#ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
 
-
-void *SAC_RTClock_createTheRTClock( void)
+void *SAC_RTClock_createTheRTClock(void)
 {
-  return((void*)0);
+    return((void*)0);
 }
 
-void SAC_RTClock_touch( void *rtclock)
+void SAC_RTClock_touch(void *rtclock)
 {
+    /* noop */
 }
 
-void SAC_RTClock_gettime( long *sec, long *nano)
+void SAC_RTClock_gettime(long *sec, long *nsec)
 {
-  struct timespec result;
+    struct timespec result;
+    result.tv_sec = 0;
+    result.tv_nsec = 0;
 
-  result.tv_sec = 0;
-  result.tv_nsec = 0;
-
-#ifdef HAVE_GETTIME_REALTIME
-
-  clock_gettime( CLOCK_REALTIME, &result);
-
-#elif HAVE_MACH_CLOCK_GET_TIME
-  clock_serv_t cclock;
-  mach_timespec_t mts;
-  host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
-  clock_get_time(cclock, &mts);
-  mach_port_deallocate(mach_task_self(), cclock);
-  result.tv_sec = mts.tv_sec;
-  result.tv_nsec = mts.tv_nsec;
-
+#ifdef __MACH__
+    // OS X does not have clock_gettime, use clock_get_time
+    clock_serv_t cclock;
+    mach_timespec_t mts;
+    host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
+    clock_get_time(cclock, &mts);
+    mach_port_deallocate(mach_task_self(), cclock);
+    result.tv_sec = mts.tv_sec;
+    result.tv_nsec = mts.tv_nsec;
 #else
-  SAC_RuntimeError( "When the stdlib was compiled for this architecture"
-                      " neither clock_gettime( CLOCK_REALTIME, x) "
-                      " nor host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, x)"
-                      " were found");
+    clock_gettime(CLOCK_REALTIME, &result);
 #endif
 
-  *sec = result.tv_sec;
-  *nano = result.tv_nsec;
+    *sec = result.tv_sec;
+    *nsec = result.tv_nsec;
 }

--- a/src/system/src/RTimer/rtimer.c
+++ b/src/system/src/RTimer/rtimer.c
@@ -12,43 +12,28 @@
  * step towards automatically inserting timer calls into the code by the compiler,
  * where we need to take recursive functions into account.
  */
-
-
-
 #include <time.h>
 #include "sac.h"
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
-#ifdef HAVE_GETTIME_REALTIME
-#include <sys/times.h>
-#elif HAVE_MACH_CLOCK_GET_TIME
+#ifdef __MACH__
 #include <mach/clock.h>
 #include <mach/mach.h>
 #endif
 
-
 struct rtimer
 {
-  struct timespec elapsed;
-  struct timespec started;
-  int instance;
+    struct timespec elapsed;
+    struct timespec started;
+    int instance;
 };
 
-
-void current_utc_time(struct timespec *ts) {
-
+void current_utc_time(struct timespec *ts)
+{
     ts->tv_sec = 0;
     ts->tv_nsec = 0;
 
-#ifdef HAVE_GETTIME_REALTIME
-
-    clock_gettime( CLOCK_REALTIME, ts);
-
-#elif HAVE_MACH_CLOCK_GET_TIME
-
+#ifdef __MACH__
+    // OS X does not have clock_gettime, use clock_get_time
     clock_serv_t cclock;
     mach_timespec_t mts;
     host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, &cclock);
@@ -56,86 +41,74 @@ void current_utc_time(struct timespec *ts) {
     mach_port_deallocate(mach_task_self(), cclock);
     ts->tv_sec = mts.tv_sec;
     ts->tv_nsec = mts.tv_nsec;
-
 #else
-    SAC_RuntimeError( "When the stdlib was compiled for this architecture"
-                      " neither clock_gettime( CLOCK_REALTIME, x) "
-                      " nor host_get_clock_service(mach_host_self(), CALENDAR_CLOCK, x)"
-                      " were found");
+    clock_gettime(CLOCK_REALTIME, ts);
 #endif
-
 }
 
-
-
-void SAC_RTimer_createRTimer( struct rtimer **ts)
+void SAC_RTimer_createRTimer(struct rtimer **ts)
 {
-  *ts = (struct rtimer *) SAC_MALLOC( sizeof( struct rtimer));
-  (*ts)->elapsed.tv_sec = 0;
-  (*ts)->elapsed.tv_nsec = 0;
-  (*ts)->started.tv_sec = 0;
-  (*ts)->started.tv_nsec = 0;
-  (*ts)->instance = 0;
+    *ts = (struct rtimer *)SAC_MALLOC(sizeof(struct rtimer));
+    (*ts)->elapsed.tv_sec = 0;
+    (*ts)->elapsed.tv_nsec = 0;
+    (*ts)->started.tv_sec = 0;
+    (*ts)->started.tv_nsec = 0;
+    (*ts)->instance = 0;
 }
 
-void SAC_RTimer_destroyRTimer( struct rtimer *ts)
+void SAC_RTimer_destroyRTimer(struct rtimer *ts)
 {
-  SAC_FREE( ts);
+    SAC_FREE(ts);
 }
 
-void SAC_RTimer_startRTimer( struct rtimer *timer)
+void SAC_RTimer_startRTimer(struct rtimer *timer)
 {
-  if (timer->instance == 0) {
-    current_utc_time(&(timer->started));
-    timer->instance += 1;
-  }
+    if (timer->instance == 0) {
+        current_utc_time(&(timer->started));
+        timer->instance += 1;
+    }
 }
 
 void SAC_RTimer_stopRTimer( struct rtimer *timer)
 {
-  struct timespec now;
-  
-  if (timer->instance == 1) {
-    current_utc_time(&now);
-    if (now.tv_nsec > timer->started.tv_nsec) {
-      timer->elapsed.tv_sec += now.tv_sec - timer->started.tv_sec;
-      timer->elapsed.tv_nsec += now.tv_nsec - timer->started.tv_nsec;
+    struct timespec now;
+
+    if (timer->instance == 1) {
+        current_utc_time(&now);
+        if (now.tv_nsec > timer->started.tv_nsec) {
+            timer->elapsed.tv_sec += now.tv_sec - timer->started.tv_sec;
+            timer->elapsed.tv_nsec += now.tv_nsec - timer->started.tv_nsec;
+        }
+        else {
+            timer->elapsed.tv_sec += (now.tv_sec - timer->started.tv_sec) - 1;
+            timer->elapsed.tv_nsec += 1000000000L - timer->started.tv_nsec + now.tv_nsec;
+        }
+
+        timer->instance = 0;
     }
-    else {
-      timer->elapsed.tv_sec += (now.tv_sec - timer->started.tv_sec) - 1;
-      timer->elapsed.tv_nsec += 1000000000L - timer->started.tv_nsec + now.tv_nsec;
+    else if (timer->instance > 1) {
+        timer->instance -= 1;
     }
-    timer->instance = 0;
-  }
-  else if (timer->instance > 1) {
-    timer->instance -= 1;
-  }
 }
 
 void SAC_RTimer_resetRTimer( struct rtimer *timer)
 {
-  if (timer->instance == 0) {
-    timer->elapsed.tv_sec = 0;
-    timer->elapsed.tv_nsec = 0;
-  }
+    if (timer->instance == 0) {
+        timer->elapsed.tv_sec = 0;
+        timer->elapsed.tv_nsec = 0;
+    }
 }
 
-
-void SAC_RTimer_getRTimerInts( struct rtimer *timer, int *sec, int *nsec)
+void SAC_RTimer_getRTimerInts(struct rtimer *timer, int *sec, int *nsec)
 {
-  *sec = (int) (timer->elapsed.tv_sec);
-  *nsec = (int) (timer->elapsed.tv_nsec);
+  *sec = (int)(timer->elapsed.tv_sec);
+  *nsec = (int)(timer->elapsed.tv_nsec);
 }
 
-double SAC_RTimer_getRTimerDbl( struct rtimer *timer)
+double SAC_RTimer_getRTimerDbl(struct rtimer *timer)
 {
-  double res;
-  
-  res = ((double) timer->elapsed.tv_sec) + ((double) timer->elapsed.tv_nsec) / 1000000000.0;
-  
-  return res;
+    double sec = (double)timer->elapsed.tv_sec;
+    double nsec = (double)timer->elapsed.tv_nsec;
+    return sec + nsec / 1000000000.0;
 }
 
-
-  
-  


### PR DESCRIPTION
Furthermore, linking with `-lrt` is only needed for glibc versions before 2.17 (https://www.man7.org/linux/man-pages/man3/clock_gettime.3.html), which was released in 2012.....

mkdtemp has been supported since version 2.19, from 2014. (https://www.man7.org/linux/man-pages/man3/mkdtemp.3.html)

HAVE_MKDTEMP and HAVE_HEADER_PRAGMA are also unused.