### PR TITLE
Integration testing with sac-examples project

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,6 +43,13 @@ jobs:
           exit 1;
         fi
         ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log
+    - name: Test
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        git clone --single-branch https://github.com/SacBase/sac-examples.git
+        cd sac-examples
+        ./test.sh
 
   build-macos-x86:
     runs-on: macos-13
@@ -84,6 +91,13 @@ jobs:
           exit 1;
         fi
         ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log
+    - name: Test
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        git clone --single-branch https://github.com/SacBase/sac-examples.git
+        cd sac-examples
+        ./test.sh
 
   build-macos-arm:
     runs-on: macos-15
@@ -125,3 +139,10 @@ jobs:
           exit 1;
         fi
         ${GITHUB_WORKSPACE}/ci/fail-on-warning.sh build.log
+    - name: Test
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+        git clone --single-branch https://github.com/SacBase/sac-examples.git
+        cd sac-examples
+        ./test.sh


### PR DESCRIPTION
Created a new project https://github.com/SacBase/sac-examples where we can store some more involved example programs to hopefully catch errors sooner.

sac-examples currently contains a few examples, but needs to be extended with a few larger examples, and the output should actually be tested. Currently, we just check if the examples compile and run without errors.