### PR TITLE
Fix SACstrstr to return the index instead of the string

### DIFF
--- a/src/structures/src/String/Str.c
+++ b/src/structures/src/String/Str.c
@@ -360,7 +360,10 @@ sac_int SACstrspn(string str, string accept)
 
 sac_int SACstrstr(string haystack, string needle)
 {
-    return (sac_int)strstr(haystack, needle);
+    char * found = strstr(haystack, needle);
+    if (found == NULL) return -1;
+    sac_int index = found - haystack;
+    return index;
 }
 
 void SACstrtok(string* out_token, string* out_rest, string str, string delimiters)


### PR DESCRIPTION
Modify SACstrstr to return the index of the needle in the haystack or -1 if not found as was specified by the specification in String.sac.