### PR TITLE
Fix dispatch ambiguities by restricting aud to audgz (d>0:shp)

### DIFF
--- a/include/arraybasics.mac
+++ b/include/arraybasics.mac
@@ -114,7 +114,7 @@ inline typ[o:oshp,i:ishp] modarray(typ[o:oshp,i:ishp] arr,                     \
 }
 
 #define MODARRAY_AxVxS(typ, _postfix, _fmt, _zval, _oval)                      \
-inline typ[d:shp] modarray(typ[d:shp] arr, int[d] idx, typ val)                \
+inline typ[d>0:shp] modarray(typ[d>0:shp] arr, int[d] idx, typ val)             \
     | _all_V_(_le_SxV_(0, idx)), _all_V_(_lt_VxV_(idx, shp))                   \
 {                                                                              \
     return _modarray_AxVxS_(arr, idx, val);                                    \

--- a/include/arraybasics.mac
+++ b/include/arraybasics.mac
@@ -114,7 +114,7 @@ inline typ[o:oshp,i:ishp] modarray(typ[o:oshp,i:ishp] arr,                     \
 }
 
 #define MODARRAY_AxVxS(typ, _postfix, _fmt, _zval, _oval)                      \
-inline typ[d>0:shp] modarray(typ[d>0:shp] arr, int[d] idx, typ val)             \
+inline typ[d:shp] modarray(typ[d:shp] arr, int[d] idx, typ val)                \
     | _all_V_(_le_SxV_(0, idx)), _all_V_(_lt_VxV_(idx, shp))                   \
 {                                                                              \
     return _modarray_AxVxS_(arr, idx, val);                                    \

--- a/src/structures/ArrayTransform.xsac
+++ b/src/structures/ArrayTransform.xsac
@@ -86,11 +86,19 @@ typ[b:shp] where(bool[b:shp] p, typ A, typ B)                                  \
              iv -> _zval         | iv < shp };                                 \
 }
 
+#define WHERE_SSS(typ, _postfix, _fmt, _zval, _oval)                           \
+inline                                                                         \
+typ where(bool p, typ A, typ B)                                                \
+{                                                                              \
+    return p ? A : B;                                                          \
+}
+
 #define WHERE(typ, postfix, fmt, zval, oval)                                   \
 WHERE_AxA(typ, postfix, fmt, zval, oval)                                       \
 WHERE_AxS(typ, postfix, fmt, zval, oval)                                       \
 WHERE_SxA(typ, postfix, fmt, zval, oval)                                       \
-WHERE_SxS(typ, postfix, fmt, zval, oval)
+WHERE_SxS(typ, postfix, fmt, zval, oval)                                       \
+WHERE_SSS(typ, postfix, fmt, zval, oval)
 
 BUILT_IN(WHERE)
 

--- a/src/structures/ArrayTransform.xsac
+++ b/src/structures/ArrayTransform.xsac
@@ -56,7 +56,7 @@ BUILT_IN(TRANSPOSE)
 
 #define WHERE_AxA(typ, _postfix, _fmt, _zval, _oval)                           \
 inline                                                                         \
-typ[d:shp] where(bool[d:shp] p, typ[d:shp] A, typ[d:shp] B)                    \
+typ[d>0:shp] where(bool[d>0:shp] p, typ[d>0:shp] A, typ[d>0:shp] B)            \
 {                                                                              \
     return { iv -> _sel_VxA_(iv, p) ? _sel_VxA_(iv, A) : _sel_VxA_(iv, B);     \
              iv -> _zval                                       | iv < shp };   \
@@ -64,7 +64,7 @@ typ[d:shp] where(bool[d:shp] p, typ[d:shp] A, typ[d:shp] B)                    \
 
 #define WHERE_AxS(typ, _postfix, _fmt, _zval, _oval)                           \
 inline                                                                         \
-typ[d:shp] where(bool[d:shp] p, typ[d:shp] A, typ B)                           \
+typ[d>0:shp] where(bool[d>0:shp] p, typ[d>0:shp] A, typ B)                     \
 {                                                                              \
     return { iv -> _sel_VxA_(iv, p) ? _sel_VxA_(iv, A) : B;                    \
              iv -> _zval                        | iv < shp };                  \
@@ -72,7 +72,7 @@ typ[d:shp] where(bool[d:shp] p, typ[d:shp] A, typ B)                           \
 
 #define WHERE_SxA(typ, _postfix, _fmt, _zval, _oval)                           \
 inline                                                                         \
-typ[d:shp] where(bool[d:shp] p, typ A, typ[d:shp] B)                           \
+typ[d>0:shp] where(bool[d>0:shp] p, typ A, typ[d>0:shp] B)                     \
 {                                                                              \
     return { iv -> _sel_VxA_(iv, p) ? A : _sel_VxA_(iv, B);                    \
              iv -> _zval                        | iv < shp };                  \

--- a/src/structures/ComplexArrayArith.xsac
+++ b/src/structures/ComplexArrayArith.xsac
@@ -21,7 +21,7 @@ export all;
 
 #define MAP_BIN_AxA(name, op, a, b, adef, bdef)                                \
 inline                                                                         \
-b[d:shp] name(a[d:shp] A, a[d:shp] B)                                          \
+b[d>0:shp] name(a[d>0:shp] A, a[d>0:shp] B)                                    \
 {                                                                              \
     return { iv -> name(A[iv], B[iv]) | iv < shp;                              \
              iv -> bdef               | iv < shp };                            \
@@ -29,7 +29,7 @@ b[d:shp] name(a[d:shp] A, a[d:shp] B)                                          \
 
 #define MAP_BIN_AxS(name, op, a, b, adef, bdef)                                \
 inline                                                                         \
-b[d:shp] name(a[d:shp] A, a B)                                                 \
+b[d>0:shp] name(a[d>0:shp] A, a B)                                             \
 {                                                                              \
     return { iv -> name(A[iv], B) | iv < shp;                                  \
              iv -> bdef           | iv < shp };                                \
@@ -37,7 +37,7 @@ b[d:shp] name(a[d:shp] A, a B)                                                 \
 
 #define MAP_BIN_SxA(name, op, a, b, adef, bdef)                                \
 inline                                                                         \
-b[d:shp] name(a A, a[d:shp] B)                                                 \
+b[d>0:shp] name(a A, a[d>0:shp] B)                                             \
 {                                                                              \
     return { iv -> name(A, B[iv]) | iv < shp;                                  \
              iv -> bdef           | iv < shp };                                \
@@ -54,7 +54,7 @@ b[d:shp] name(a A, a[d:shp] B)                                                 \
 
 #define MAP_MON_AxA(name, op, a, b, adef, bdef)                                \
 inline                                                                         \
-b[d:shp] name(a[d:shp] A)                                                      \
+b[d>0:shp] name(a[d>0:shp] A)                                                  \
 {                                                                              \
     return { iv -> name(A[iv]) | iv < shp;                                     \
              iv -> bdef        | iv < shp };                                   \

--- a/src/structures/Quaternion.xsac
+++ b/src/structures/Quaternion.xsac
@@ -83,20 +83,20 @@ inline struct Quaternion *(struct Quaternion a, struct Quaternion b)
     };
 }
 
-inline struct Quaternion[d:shp] *(struct Quaternion a,
-                                  struct Quaternion[d:shp] b)
+inline struct Quaternion[d>0:shp] *(struct Quaternion a,
+                                    struct Quaternion[d>0:shp] b)
 {
     return { iv -> a * b[iv] | iv < shp };
 }
 
-inline struct Quaternion[d:shp] *(struct Quaternion[d:shp] a,
-                                  struct Quaternion b)
+inline struct Quaternion[d>0:shp] *(struct Quaternion[d>0:shp] a,
+                                    struct Quaternion b)
 {
     return { iv -> a[iv] * b | iv < shp };
 }
 
-inline struct Quaternion[d:shp] *(struct Quaternion[d:shp] a,
-                                  struct Quaternion[d:shp] b)
+inline struct Quaternion[d>0:shp] *(struct Quaternion[d>0:shp] a,
+                                    struct Quaternion[d>0:shp] b)
 {
     return { iv -> a[iv] * b[iv] | iv < shp };
 }


### PR DESCRIPTION
Replace [d:shp] with [d>0:shp] in commutative overload pairs where one function was more specific in one arg position but less specific in another, causing the new dispatch rule to reject them.

- Quaternion.xsac: * operator scalar×aud / aud×scalar overloads
- arraybasics.mac: MODARRAY_AxVxS conflicting with MODARRAY_AxSxA
- ArrayTransform.xsac: WHERE AxS / SxA overloads
- ComplexArrayArith.xsac: MAP_BIN AxS / SxA overloads

Has to do with: https://gitlab.sac-home.org/sac-group/sac2c/-/merge_requests/637